### PR TITLE
Fix attributes

### DIFF
--- a/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
@@ -165,14 +165,14 @@ namespace ApiDoctor.Publishing.CSDL
                 {
                     foreach(var param in action.Parameters.Where(x => x.Name == "bindingParameter" || x.Name == "this")) {
                         param.Name = "bindingParameter";
-                        param.Nullable = null;
+                        param.IsNullable = null;
                     }
                 }
                 foreach(var func in schema.Functions)
                 {
                     foreach (var param in func.Parameters.Where(x => x.Name == "bindingParameter" || x.Name == "this")) {
                         param.Name = "bindingParameter";
-                        param.Nullable = null;
+                        param.IsNullable = null;
                     }
                 }
             }

--- a/ApiDoctor.Publishing/CSDL/csdlwriter.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlwriter.cs
@@ -809,7 +809,7 @@ namespace ApiDoctor.Publishing.CSDL
 
             target.Name = name.TypeOnly();
             target.IsBound = true;
-            target.Parameters.Add(new Parameter { Name = "bindingParameter", Type = boundToType, Nullable = false });
+            target.Parameters.Add(new Parameter { Name = "bindingParameter", Type = boundToType, IsNullable = false });
             foreach (var param in methodCollection.Where(m => m.HttpMethodVerb() == "POST").SelectMany(m => m.RequestBodyParameters))
             {
                 try
@@ -826,7 +826,7 @@ namespace ApiDoctor.Publishing.CSDL
                             {
                                 Name = param.Name,
                                 Type = param.Type.ODataResourceName(),
-                                Nullable = (param.Required.HasValue ? param.Required.Value : false)
+                                IsNullable = (param.Required.HasValue ? param.Required.Value : false)
                             });
                     }
                 }
@@ -858,7 +858,7 @@ namespace ApiDoctor.Publishing.CSDL
                             {
                                 Name = matchingParamDef.Name,
                                 Type = matchingParamDef.Type.ODataResourceName(),
-                                Nullable = (matchingParamDef.Required.GetValueOrDefault())
+                                IsNullable = (matchingParamDef.Required.GetValueOrDefault())
                             });
 
                         // if we have an optional param, recursively call again without it

--- a/ApiDoctor.Validation/OData/Action.cs
+++ b/ApiDoctor.Validation/OData/Action.cs
@@ -107,7 +107,7 @@ namespace ApiDoctor.Validation.OData
                     if (otherParameter == null ||
                         otherParameter.Type == null ||
                         thisParameter.Type == null ||
-                        otherParameter.Nullable != thisParameter.Nullable ||
+                        otherParameter.IsNullable != thisParameter.IsNullable ||
                         otherParameter.Unicode != thisParameter.Unicode)
                     {
                         return false;

--- a/ApiDoctor.Validation/OData/ComplexType.cs
+++ b/ApiDoctor.Validation/OData/ComplexType.cs
@@ -45,17 +45,17 @@ namespace ApiDoctor.Validation.OData
             this.Annotation = new List<Annotation>();
         }
 
+        [XmlAttribute("Name"), SortBy]
+        public string Name { get; set; }
+        
+        [XmlAttribute("BaseType"), ContainsType, MergePolicy(MergePolicy.EqualOrNull)]
+        public string BaseType { get; set; }
+
         [XmlAttribute("Abstract"), DefaultValue(false), MergePolicy(MergePolicy.PreferTrueValue)]
         public bool Abstract { get; set; }
 
-        [XmlAttribute("Name"), SortBy]
-        public string Name { get; set; }
-
         [XmlAttribute("OpenType"), DefaultValue(false), MergePolicy(MergePolicy.PreferGreaterValue)]
         public bool OpenType { get; set; }
-
-        [XmlAttribute("BaseType"), ContainsType, MergePolicy(MergePolicy.EqualOrNull)]
-        public string BaseType { get; set; }
 
         [XmlElement("Property", Namespace = ODataParser.EdmNamespace), Sortable]
         public List<Property> Properties { get; set; }

--- a/ApiDoctor.Validation/OData/Parameter.cs
+++ b/ApiDoctor.Validation/OData/Parameter.cs
@@ -89,11 +89,21 @@ namespace ApiDoctor.Validation.OData
             }
         }
 
+        private bool _isUnicode;
+
         [XmlAttribute("Unicode"), MergePolicy(MergePolicy.Ignore)]
-        public bool UnicodePropertyValue { get; set; }
+        public bool UnicodePropertyValue
+        {
+            get { return _isUnicode; }
+            set
+            {
+                _isUnicode = value;
+                UnicodePropertyValueSpecified = true;
+            }
+        }
 
         [XmlIgnore]
-        public bool UnicodePropertyValueSpecified => this.Type == "Edm.String";
+        public bool UnicodePropertyValueSpecified { get; set; }
 
         [XmlIgnore, MergePolicy(MergePolicy.PreferFalseValue)]
         public bool? Unicode

--- a/ApiDoctor.Validation/OData/Parameter.cs
+++ b/ApiDoctor.Validation/OData/Parameter.cs
@@ -25,8 +25,6 @@
 
 namespace ApiDoctor.Validation.OData
 {
-    using System;
-    using System.ComponentModel;
     using System.Xml.Serialization;
     using Transformation;
     using Utility;
@@ -34,6 +32,9 @@ namespace ApiDoctor.Validation.OData
     [XmlRoot("Parameter", Namespace = ODataParser.EdmNamespace), Mergable(CollectionIdentifier = "Name")]
     public class Parameter : XmlBackedTransformableObject
     {
+        private bool nullable;
+        private bool isUnicode;
+
         public Parameter()
         {
         }
@@ -44,33 +45,37 @@ namespace ApiDoctor.Validation.OData
         [XmlAttribute("Type"), ContainsType]
         public string Type { get; set; }
 
-        private bool _isNullable;
-
-        [XmlAttribute("Nullable"), MergePolicy(MergePolicy.Ignore)]
-        public bool ValueOfNullableProp
+        [XmlAttribute("Nullable"), MergePolicy(MergePolicy.PreferFalseValue)]
+        public bool Nullable
         {
-            get { return _isNullable; }
+            get { return this.nullable; }
             set
             {
-                _isNullable = value;
-                ValueOfNullablePropSpecified = true;
+                this.nullable = value;
+                this.NullableSpecified = true;
             }
         }
 
+        /// <summary>
+        /// Nullable + NullableSpecified are based on some convention  
+        /// </summary>
         [XmlIgnore]
-        public bool ValueOfNullablePropSpecified { get; set; }
+        public bool NullableSpecified { get; set; }
 
         [XmlIgnore, MergePolicy(MergePolicy.Ignore)]
         public bool ValueOfNullablePropertySpecified { get; set; }
 
+        /// <summary>
+        /// This appears to be used for merging.
+        /// </summary>
         [XmlIgnore, MergePolicy(MergePolicy.PreferFalseValue)]
-        public bool? Nullable
+        public bool? IsNullable
         {
             get
             {
-                if (ValueOfNullablePropertySpecified)
+                if (this.ValueOfNullablePropertySpecified)
                 {
-                    return ValueOfNullableProp;
+                    return this.Nullable;
                 }
                 return null;
             }
@@ -79,26 +84,24 @@ namespace ApiDoctor.Validation.OData
             {
                 if (!value.HasValue)
                 {
-                    ValueOfNullablePropertySpecified = false;
+                    this.ValueOfNullablePropertySpecified = false;
                 }
                 else
                 {
-                    ValueOfNullablePropertySpecified = true;
-                    ValueOfNullableProp = value.Value;
+                    this.ValueOfNullablePropertySpecified = true;
+                    this.Nullable = value.Value;
                 }
             }
         }
 
-        private bool _isUnicode;
-
         [XmlAttribute("Unicode"), MergePolicy(MergePolicy.Ignore)]
         public bool UnicodePropertyValue
         {
-            get { return _isUnicode; }
+            get { return this.isUnicode; }
             set
             {
-                _isUnicode = value;
-                UnicodePropertyValueSpecified = true;
+                this.isUnicode = value;
+                this.UnicodePropertyValueSpecified = true;
             }
         }
 
@@ -112,7 +115,7 @@ namespace ApiDoctor.Validation.OData
             {
                 if (UnicodePropertyValueSpecified)
                 {
-                    return UnicodePropertyValue;
+                    return this.UnicodePropertyValue;
                 }
 
                 return null;
@@ -121,7 +124,7 @@ namespace ApiDoctor.Validation.OData
             {
                 if (value.HasValue)
                 {
-                    UnicodePropertyValue = value.Value;
+                    this.UnicodePropertyValue = value.Value;
                 }
             }
         }

--- a/ApiDoctor.Validation/OData/Parameter.cs
+++ b/ApiDoctor.Validation/OData/Parameter.cs
@@ -44,11 +44,21 @@ namespace ApiDoctor.Validation.OData
         [XmlAttribute("Type"), ContainsType]
         public string Type { get; set; }
 
+        private bool _isNullable;
+
         [XmlAttribute("Nullable"), MergePolicy(MergePolicy.Ignore)]
-        public bool ValueOfNullableProp { get; set; }
+        public bool ValueOfNullableProp
+        {
+            get { return _isNullable; }
+            set
+            {
+                _isNullable = value;
+                ValueOfNullablePropSpecified = true;
+            }
+        }
 
         [XmlIgnore]
-        public bool ValueOfNullablePropSpecified => this.ValueOfNullableProp;
+        public bool ValueOfNullablePropSpecified { get; set; }
 
         [XmlIgnore, MergePolicy(MergePolicy.Ignore)]
         public bool ValueOfNullablePropertySpecified { get; set; }

--- a/ApiDoctor.Validation/OData/Property.cs
+++ b/ApiDoctor.Validation/OData/Property.cs
@@ -25,9 +25,7 @@
 
 namespace ApiDoctor.Validation.OData
 {
-    using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Xml.Serialization;
     using Transformation;
     using Utility;
@@ -35,6 +33,9 @@ namespace ApiDoctor.Validation.OData
     [XmlRoot("Property", Namespace = ODataParser.EdmNamespace), Mergable(CollectionIdentifier = "Name")]
     public class Property : XmlBackedTransformableObject, IODataAnnotatable
     {
+        private bool isUnicode;
+        private bool nullable;
+
         public Property()
         {
             this.Annotation = new List<Annotation>();
@@ -46,45 +47,32 @@ namespace ApiDoctor.Validation.OData
         [XmlAttribute("Type"), ContainsType, MergePolicy(MergePolicy.PreferLesserValue)]
         public string Type { get; set; }
 
-        [XmlIgnore]
-        private bool _nullable;
-
         [XmlAttribute("Nullable"), MergePolicy(MergePolicy.PreferFalseValue)]
         public bool Nullable {
-            get { return _nullable; }
+            get { return this.nullable; }
             set
             {
-                _nullable = value;
-                NullableSpecified = true;
+                this.nullable = value;
+                this.NullableSpecified = true;
             }
         }
 
         [XmlIgnore]
         public bool NullableSpecified{ get; set;}
 
-        [XmlIgnore]
-        private bool _isUnicode;
-
         [XmlAttribute("Unicode"), MergePolicy(MergePolicy.PreferFalseValue)]
         public bool Unicode
         {
-            get => _isUnicode;
+            get { return this.isUnicode; } 
             set
             {
-                _isUnicode = value;
-                UnicodeSpecified = true;
+                this.isUnicode = value;
+                this.UnicodeSpecified = true;
             }
         }
 
         [XmlIgnore]
-        private bool _isUnicodeSpecified;
-
-        [XmlIgnore]
-        public bool UnicodeSpecified
-        {
-            get => _isUnicodeSpecified;
-            set { _isUnicodeSpecified = value; }
-        }
+        public bool UnicodeSpecified { get; set; }
 
         [XmlElement("Annotation", Namespace = ODataParser.EdmNamespace), Sortable]
         public List<Annotation> Annotation { get; set; }

--- a/ApiDoctor.Validation/OData/Property.cs
+++ b/ApiDoctor.Validation/OData/Property.cs
@@ -37,7 +37,6 @@ namespace ApiDoctor.Validation.OData
     {
         public Property()
         {
-            Unicode = false;
             this.Annotation = new List<Annotation>();
         }
 
@@ -47,15 +46,45 @@ namespace ApiDoctor.Validation.OData
         [XmlAttribute("Type"), ContainsType, MergePolicy(MergePolicy.PreferLesserValue)]
         public string Type { get; set; }
 
-        [XmlAttribute("Nullable"), MergePolicy(MergePolicy.PreferTrueValue)]
-        public bool Nullable { get; set; }
+        [XmlIgnore]
+        private bool _nullable;
+
+        [XmlAttribute("Nullable"), MergePolicy(MergePolicy.PreferFalseValue)]
+        public bool Nullable {
+            get { return _nullable; }
+            set
+            {
+                _nullable = value;
+                NullableSpecified = true;
+            }
+        }
 
         [XmlIgnore]
-        public bool NullableSpecified => this.Nullable;
+        public bool NullableSpecified{ get; set;}
+
+        [XmlIgnore]
+        private bool _isUnicode;
 
         [XmlAttribute("Unicode"), MergePolicy(MergePolicy.PreferFalseValue)]
-        public bool Unicode { get; set; }
-        public bool UnicodeSpecified => "Edm.String".Equals(this.Type);
+        public bool Unicode
+        {
+            get => _isUnicode;
+            set
+            {
+                _isUnicode = value;
+                UnicodeSpecified = true;
+            }
+        }
+
+        [XmlIgnore]
+        private bool _isUnicodeSpecified;
+
+        [XmlIgnore]
+        public bool UnicodeSpecified
+        {
+            get => _isUnicodeSpecified;
+            set { _isUnicodeSpecified = value; }
+        }
 
         [XmlElement("Annotation", Namespace = ODataParser.EdmNamespace), Sortable]
         public List<Annotation> Annotation { get; set; }

--- a/ApiDoctor.Validation/OData/ReturnType.cs
+++ b/ApiDoctor.Validation/OData/ReturnType.cs
@@ -25,7 +25,6 @@
 
 namespace ApiDoctor.Validation.OData
 {
-    using System;
     using System.ComponentModel;
     using System.Xml.Serialization;
     using Transformation;
@@ -34,6 +33,8 @@ namespace ApiDoctor.Validation.OData
     [XmlRoot("ReturnType", Namespace = ODataParser.EdmNamespace), Mergable]
     public class ReturnType : XmlBackedTransformableObject
     {
+        private bool isNullable;
+
         public ReturnType()
         {
             this.Unicode = true;
@@ -42,16 +43,14 @@ namespace ApiDoctor.Validation.OData
         [XmlAttribute("Type"), ContainsType]
         public string Type { get; set; }
 
-        private bool _isNullable;
-
         [XmlAttribute("Nullable"), MergePolicy(MergePolicy.PreferFalseValue)]
         public bool Nullable
         {
-            get { return _isNullable; }
+            get { return this.isNullable; }
             set
             {
-                _isNullable = value;
-                NullableSpecified = true;
+                this.isNullable = value;
+                this.NullableSpecified = true;
             }
         }
 

--- a/ApiDoctor.Validation/OData/ReturnType.cs
+++ b/ApiDoctor.Validation/OData/ReturnType.cs
@@ -42,11 +42,21 @@ namespace ApiDoctor.Validation.OData
         [XmlAttribute("Type"), ContainsType]
         public string Type { get; set; }
 
-        [XmlAttribute("Nullable"), DefaultValue(false)]
-        public bool Nullable { get; set; }
+        private bool _isNullable;
+
+        [XmlAttribute("Nullable"), MergePolicy(MergePolicy.PreferFalseValue)]
+        public bool Nullable
+        {
+            get { return _isNullable; }
+            set
+            {
+                _isNullable = value;
+                NullableSpecified = true;
+            }
+        }
 
         [XmlIgnore]
-        public bool NullableSpecified => this.Nullable;
+        public bool NullableSpecified { get; set; }
 
         [XmlAttribute("Unicode"), DefaultValue(true)]
         public bool Unicode { get; set; }


### PR DESCRIPTION
We found that there were attributes being stripped or being added when they shouldn't be. This fix addresses those issues. Additionally, I changed the order of properties to maintain the input order per what appears to be Graph standard. More notes in the commits. 

`publish-edmx --path D:\repos\docs\api-reference\v1.0 --source D:\metadata\2018_09_14\v1.0_2018_09_14_source_clean.xml --output finalmetadata2 --skip-generation`

![image](https://user-images.githubusercontent.com/8527305/46326739-19f36700-c5b3-11e8-9837-0af4941ec357.png)
