### PR TITLE
Reenables the skip-generation option

### DIFF
--- a/ApiDoctor.Publishing/CSDL/csdlwriter.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlwriter.cs
@@ -197,7 +197,7 @@ namespace ApiDoctor.Publishing.CSDL
 
             bool generateNewElements = (generateFromDocs == null && !options.SkipMetadataGeneration) || (generateFromDocs.HasValue && generateFromDocs.Value);
 
-            // Add resources
+            // Add resources and add new elements from the documentation if they don't already exist.
             if (generateNewElements && Documents.Files.Any())
             {
                 foreach (var resource in this.Documents.Resources)
@@ -247,6 +247,19 @@ namespace ApiDoctor.Publishing.CSDL
                     }
 
                     defaultSchema.Enumerations.Add(enumType);
+                }
+            }
+
+            // Skip-generation of new elements, add doc annotations to existing elements.
+            if(!generateNewElements)
+            {
+                foreach (var resource in Documents.Resources)
+                {
+                    var targetSchema = FindOrCreateSchemaForNamespace(resource.Name.NamespaceOnly(), edmx, generateNewElements: generateNewElements);
+                    if (targetSchema != null)
+                    {
+                        AddResourceToSchema(targetSchema, resource, edmx, issues, generateNewElements: generateNewElements);
+                    }
                 }
             }
 


### PR DESCRIPTION
When creating ApiDoctor from MarkdownScanner, the skip-generation feature got disabled. This change re-enables it. You can see the output with this command:

`apidocs.exe publish-edmx --path C:\repos\microsoft-graph-docs\api-reference\v1.0 --source c:\repos\MSGraph-SDK-Code-Generator\metadata\2018_10_23\v1.0_2018_10_23_source_clean.xml --output metadataPropertiesSkip --annotations Properties --skip-generation`

@darrelmiller