### PR TITLE
Make nuspec and project reference match for JSON.Net

### DIFF
--- a/ApiDoctor.Publishing/ApiDoctor.Publishing.nuspec
+++ b/ApiDoctor.Publishing/ApiDoctor.Publishing.nuspec
@@ -13,7 +13,7 @@
         <copyright>Copyright Microsoft</copyright>
         <dependencies>
             <group targetFramework=".NETFramework4.5">
-                <dependency id="Newtonsoft.Json" version="7.0.1" />
+                <dependency id="Newtonsoft.Json" version="6.0.8" />
                 <dependency id="ApiDoctor.Validation" version="$version$" />
             </group>
         </dependencies>

--- a/ApiDoctor.Validation/ApiDoctor.Validation.nuspec
+++ b/ApiDoctor.Validation/ApiDoctor.Validation.nuspec
@@ -13,7 +13,7 @@
         <copyright>Copyright Microsoft</copyright>
         <dependencies>
             <group targetFramework=".NETFramework4.5">
-                <dependency id="Newtonsoft.Json" version="7.0.1" />
+                <dependency id="Newtonsoft.Json" version="6.0.8" />
             </group>
         </dependencies>
         <frameworkAssemblies>


### PR DESCRIPTION
The project and nuspec reference for JSON.Net do not match. This means their is a major version mismatch between the version used to build apidoctor.publisher and apidoctpr.validation, and what is downloaded as a dependency to the built nuget packages. 

https://github.com/OneDrive/apidoctor/blob/master/ApiDoctor.Publishing/ApiDoctor.Publishing.csproj#L36
https://github.com/OneDrive/apidoctor/blob/master/ApiDoctor.Validation/ApiDoctor.Validation.csproj#L45

@darrelmiller