### PR TITLE
Support nested Json collections.

### DIFF
--- a/ApiDoctor.Validation/ParameterDataType.cs
+++ b/ApiDoctor.Validation/ParameterDataType.cs
@@ -424,6 +424,7 @@ namespace ApiDoctor.Validation
             Int64 = new ParameterDataType(SimpleDataType.Int64);
             Int32 = new ParameterDataType(SimpleDataType.Int32);
             DateTimeOffset = new ParameterDataType(SimpleDataType.DateTimeOffset);
+            JsonCollection = new ParameterDataType(SimpleDataType.Json, isCollection: false);
         }
 
         public static ParameterDataType String
@@ -466,6 +467,14 @@ namespace ApiDoctor.Validation
         {
             get; private set;
         }
+        public static ParameterDataType Json
+        {
+            get; private set;
+        }
+        public static ParameterDataType JsonCollection
+        {
+            get; private set;
+        }
 
         #endregion
     }
@@ -481,7 +490,7 @@ namespace ApiDoctor.Validation
         Int16,
         Int32,
         Int64,
-        
+
         Float,
         Double,
 
@@ -505,6 +514,10 @@ namespace ApiDoctor.Validation
 
         Single,
 
-        Binary
+        Binary,
+        /// <summary>
+        /// Specified Json (including Json collections)
+        /// </summary>
+        Json
     }
 }


### PR DESCRIPTION
Nested Json objects, where there is an array inside an array cause type mismatch errors. This PR fixes this bug by turning nested collections into a JsonCollection that is assumed to be an object. 
`
{
"values" : [["Hello", "100"],["1/1/2016", null]],
"formula" : [[null, null], [null, "=B1*2"]],
"numberFormat" : [[null,null], ["m-ddd", null]]
}
`