### PR TITLE
Respect Ignore warnings flag.

### DIFF
--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -231,7 +231,7 @@ namespace ApiDoctor.ConsoleApp
             if (returnSuccess)
             {
                 if (issues.Errors.Any() ||
-                    (issues.Warnings.Any() && !options.IgnoreErrors))
+                    (issues.Warnings.Any() && !options.IgnoreErrors && !options.IgnoreWarnings))
                 {
                     returnSuccess = false;
                 }

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -230,8 +230,8 @@ namespace ApiDoctor.ConsoleApp
 
             if (returnSuccess)
             {
-                if (issues.Errors.Any() ||
-                    (issues.Warnings.Any() && !options.IgnoreErrors && !options.IgnoreWarnings))
+                if ((issues.Errors.Any() && !options.IgnoreErrors) ||
+                    (issues.Warnings.Any() && !options.IgnoreWarnings))
                 {
                     returnSuccess = false;
                 }


### PR DESCRIPTION
ApiDoctor does not respect the --ignore-warnings flag. 
We need to respect this flag since we have the new "treatErrorsAsWarnings" section that allows us to treat errors in certain workloads as warnings. 