### PR TITLE
Validation Rule: Enforce lowercase file names in urls

### DIFF
--- a/ApiDoctor.Validation.UnitTests/BrokenLinkTests.cs
+++ b/ApiDoctor.Validation.UnitTests/BrokenLinkTests.cs
@@ -85,7 +85,6 @@ This link goes [up one level](../anotherfile.md)
             Assert.IsTrue(realErrors.First().Code == ValidationErrorCode.MissingLinkSourceId);
         }
 
-
         [Test]
         public void BrokenLinkNotFound()
         {
@@ -149,6 +148,27 @@ This link goes [up one level](../anotherfile.md)
             Assert.AreEqual(2, issues.Issues.WarningsOrErrorsOnly().Count());
             Assert.IsTrue(issues.Issues.Any(i => i.Code == ValidationErrorCode.MissingLinkSourceId));
             Assert.IsTrue(issues.Issues.Any(i => i.Code == ValidationErrorCode.LinkDestinationNotFound));
+        }
+
+        [Test]
+        public void UpperCaseUrlsTreatedAsBroken()
+        {
+            string markdown =
+                @"# Test file
+[Basic Link with Uppercase](http://www.Microsoft.Com/).
+[ID-based link with Uppercase][Microsoft]
+[Up one level with Uppercase](../GET-USER.md)
+
+[microsoft with uppercase]: http://www.microsoFt.com
+";
+            TestableDocFile file = new TestableDocFile(markdown);
+            var issues = new IssueLogger();
+
+            Assert.IsTrue(file.Scan(string.Empty, issues));
+            Assert.IsEmpty(issues.Issues.WarningsOrErrorsOnly());
+
+            Assert.IsFalse(file.ValidateNoBrokenLinks(false, issues, true));
+            Assert.IsNotEmpty(issues.Issues.WarningsOrErrorsOnly());
         }
     }
 

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -1347,6 +1347,9 @@ namespace ApiDoctor.Validation
                             linkedPages.Add(relativeFileName);
                         }
                         break;
+                    case LinkValidationResult.InvalidUpperCaseCharacterInUrl:
+                        issues.Error(ValidationErrorCode.LinkInvalidUpperCaseCharacterInUrl, $"InvalidUpperCaseCharacterInUrl '[{link.Definition.url}]({link.Text})'.");
+                        break;
                     default:
                         issues.Error(ValidationErrorCode.Unknown, $"{result}: Link '[{link.Text}]({link.Definition.url})'.");
                         break;
@@ -1367,7 +1370,8 @@ namespace ApiDoctor.Validation
             ParentAboveDocSetPath,
             BookmarkMissing,
             FileExistsBookmarkValidationSkipped,
-            BookmarkSkippedDocFileNotFound
+            BookmarkSkippedDocFileNotFound,
+            InvalidUpperCaseCharacterInUrl
         }
 
         protected LinkValidationResult VerifyLink(string docFilePath, string linkUrl, string docSetBasePath, out string relativeFileName, bool requireFilenameCaseMatch)
@@ -1399,6 +1403,10 @@ namespace ApiDoctor.Validation
                             relativeFileName = "#" + suggestion;
                         return LinkValidationResult.BookmarkMissing;
                     }
+                }
+                else if (linkUrl.Any(char.IsUpper))
+                {
+                    return LinkValidationResult.InvalidUpperCaseCharacterInUrl;
                 }
                 else
                 {

--- a/ApiDoctor.Validation/Error/validationerror.cs
+++ b/ApiDoctor.Validation/Error/validationerror.cs
@@ -69,6 +69,7 @@ namespace ApiDoctor.Validation.Error
         LinkDestinationNotFound,
         LinkDestinationOutsideDocSet,
         LinkFormatInvalid,
+        LinkInvalidUpperCaseCharacterInUrl,
 
         MissingRequiredArguments,
         MissingAccessToken,


### PR DESCRIPTION
All Urls should be in lowercase. 

so we don't have 
"GET-USER.md"
we have
"get-user.md"

Includes test to verify this. 

