### PR TITLE
Validation Rule: Enforce lowercase file names in urls and Azure Pipeline setup

### DIFF
--- a/ApiDoctor.Validation.UnitTests/BrokenLinkTests.cs
+++ b/ApiDoctor.Validation.UnitTests/BrokenLinkTests.cs
@@ -85,7 +85,6 @@ This link goes [up one level](../anotherfile.md)
             Assert.IsTrue(realErrors.First().Code == ValidationErrorCode.MissingLinkSourceId);
         }
 
-
         [Test]
         public void BrokenLinkNotFound()
         {
@@ -149,6 +148,27 @@ This link goes [up one level](../anotherfile.md)
             Assert.AreEqual(2, issues.Issues.WarningsOrErrorsOnly().Count());
             Assert.IsTrue(issues.Issues.Any(i => i.Code == ValidationErrorCode.MissingLinkSourceId));
             Assert.IsTrue(issues.Issues.Any(i => i.Code == ValidationErrorCode.LinkDestinationNotFound));
+        }
+
+        [Test]
+        public void UpperCaseUrlsTreatedAsBroken()
+        {
+            string markdown =
+                @"# Test file
+[Basic Link with Uppercase](http://www.Microsoft.Com/).
+[ID-based link with Uppercase][Microsoft]
+[Up one level with Uppercase](../GET-USER.md)
+
+[microsoft with uppercase]: http://www.microsoFt.com
+";
+            TestableDocFile file = new TestableDocFile(markdown);
+            var issues = new IssueLogger();
+
+            Assert.IsTrue(file.Scan(string.Empty, issues));
+            Assert.IsEmpty(issues.Issues.WarningsOrErrorsOnly());
+
+            Assert.IsFalse(file.ValidateNoBrokenLinks(false, issues, true));
+            Assert.IsNotEmpty(issues.Issues.WarningsOrErrorsOnly());
         }
     }
 

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -1347,6 +1347,9 @@ namespace ApiDoctor.Validation
                             linkedPages.Add(relativeFileName);
                         }
                         break;
+                    case LinkValidationResult.InvalidUpperCaseCharacterInUrl:
+                        issues.Error(ValidationErrorCode.LinkInvalidUpperCaseCharacterInUrl, $"InvalidUpperCaseCharacterInUrl '[{link.Definition.url}]({link.Text})'.");
+                        break;
                     default:
                         issues.Error(ValidationErrorCode.Unknown, $"{result}: Link '[{link.Text}]({link.Definition.url})'.");
                         break;
@@ -1367,7 +1370,8 @@ namespace ApiDoctor.Validation
             ParentAboveDocSetPath,
             BookmarkMissing,
             FileExistsBookmarkValidationSkipped,
-            BookmarkSkippedDocFileNotFound
+            BookmarkSkippedDocFileNotFound,
+            InvalidUpperCaseCharacterInUrl
         }
 
         protected LinkValidationResult VerifyLink(string docFilePath, string linkUrl, string docSetBasePath, out string relativeFileName, bool requireFilenameCaseMatch)
@@ -1399,6 +1403,10 @@ namespace ApiDoctor.Validation
                             relativeFileName = "#" + suggestion;
                         return LinkValidationResult.BookmarkMissing;
                     }
+                }
+                else if (linkUrl.Any(char.IsUpper))
+                {
+                    return LinkValidationResult.InvalidUpperCaseCharacterInUrl;
                 }
                 else
                 {

--- a/ApiDoctor.Validation/Error/validationerror.cs
+++ b/ApiDoctor.Validation/Error/validationerror.cs
@@ -69,6 +69,7 @@ namespace ApiDoctor.Validation.Error
         LinkDestinationNotFound,
         LinkDestinationOutsideDocSet,
         LinkFormatInvalid,
+        LinkInvalidUpperCaseCharacterInUrl,
 
         MissingRequiredArguments,
         MissingAccessToken,

--- a/Test-Docs.ps1
+++ b/Test-Docs.ps1
@@ -24,7 +24,7 @@ New-Item -Path $fullDocsPath -ItemType Directory -Force
 Write-Host "Cloning Microsoft Graph Docs from Github"
 Write-Host "`tRemote URL: $graphDocsRepo"
 Write-Host "`tBranch: $graphDocsBranch"
-Invoke-Expression "git clone -b $graphDocsBranch $graphDocsRepo --recurse-submodules $fullDocsPath"
+& git clone -b $graphDocsBranch $graphDocsRepo --recurse-submodules $fullDocsPath
 
 & $apiDoctor $params
 

--- a/Test-Docs.ps1
+++ b/Test-Docs.ps1
@@ -24,7 +24,17 @@ New-Item -Path $graphDocsPath -ItemType Directory -Force
 Write-Host "Cloning Microsoft Graph Docs from Github"
 Write-Host "`tRemote URL: $graphDocsRepo"
 Write-Host "`tBranch: $graphDocsBranch"
-& git clone -b $graphDocsBranch $graphDocsRepo --recurse-submodules $fullDocsPath
+$result = Invoke-Expression "git clone -b $graphDocsBranch $graphDocsRepo --recurse-submodules $fullDocsPath"
 
 & $apiDoctor $params
 
+# Clean up the stuff we downloaded
+if ($cleanUp -eq $true) {
+   Remove-Item $graphDocsPath -Recurse -Force
+}
+Write-Host $result
+if ($LastExitCode -ne 0) {
+    Write-Host "Errors were detected. This build failed."
+    Write-Host $LastExitCode
+    exit $LastExitCode
+}

--- a/Test-Docs.ps1
+++ b/Test-Docs.ps1
@@ -1,0 +1,46 @@
+Param(
+    [switch]$cleanUp,
+    [Parameter(Mandatory)]
+	[string]$apiDoctorPath,
+    [Parameter(Mandatory)]
+	[string]$docSubPath,
+    [Parameter(Mandatory)]
+	[string]$graphDocsRepo,
+    [Parameter(Mandatory)]
+	[string]$graphDocsBranch,
+    [Parameter(Mandatory)]
+	[string]$graphDocsPath
+)
+$repoPath = (Get-Location).Path
+$fullDocsPath = Join-Path $repoPath $graphDocsPath
+$fullDocsSubPath =  Join-Path $fullDocsPath $docSubPath
+$params ="check-all", "--path", "$fullDocsSubPath", "--ignore-warnings"
+$apiDoctor = Join-Path $repoPath $apiDoctorPath
+
+Write-Host $repoPath
+Write-Host $docSubPath
+Write-Host $fullDocsPath
+Write-Host $fullDocsSubPath
+Write-Host $params
+Write-Host $apiDoctor
+
+#Clone Docs Repo
+New-Item -Path $fullDocsPath -ItemType Directory
+Write-Host "Cloning Microsoft Graph Docs from Github"
+Write-Host "`tRemote URL: $graphDocsRepo"
+Write-Host "`tBranch: $graphDocsBranch"
+Invoke-Expression "git clone -b $graphDocsBranch $graphDocsRepo --recurse-submodules $fullDocsPath"
+
+& $apiDoctor $params
+
+# Clean up the stuff we downloaded
+if ($cleanUp -eq $true) {
+   Remove-Item $graphDocsPath -Recurse -Force
+}
+
+
+if ($LastExitCode -ne 0) {
+    Write-Host "Errors were detected. This build failed."
+    Write-Host $LastExitCode
+    exit $LastExitCode
+}

--- a/Test-Docs.ps1
+++ b/Test-Docs.ps1
@@ -33,14 +33,3 @@ Invoke-Expression "git clone -b $graphDocsBranch $graphDocsRepo --recurse-submod
 
 & $apiDoctor $params
 
-# Clean up the stuff we downloaded
-if ($cleanUp -eq $true) {
-   Remove-Item $graphDocsPath -Recurse -Force
-}
-
-
-if ($LastExitCode -ne 0) {
-    Write-Host "Errors were detected. This build failed."
-    Write-Host $LastExitCode
-    exit $LastExitCode
-}

--- a/Test-Docs.ps1
+++ b/Test-Docs.ps1
@@ -19,9 +19,6 @@ Write-Host $fullDocsSubPath
 Write-Host $params
 Write-Host $apiDoctor
 
-Test-Connection -ComputerName github.com -Count 4 -Verbose
-
-
 #Clone Docs Repo
 New-Item -Path $graphDocsPath -ItemType Directory -Force
 Write-Host "Cloning Microsoft Graph Docs from Github"

--- a/Test-Docs.ps1
+++ b/Test-Docs.ps1
@@ -1,14 +1,9 @@
 Param(
     [switch]$cleanUp,
-    [Parameter(Mandatory)]
 	[string]$apiDoctorPath,
-    [Parameter(Mandatory)]
 	[string]$docSubPath,
-    [Parameter(Mandatory)]
 	[string]$graphDocsRepo,
-    [Parameter(Mandatory)]
 	[string]$graphDocsBranch,
-    [Parameter(Mandatory)]
 	[string]$graphDocsPath
 )
 $repoPath = (Get-Location).Path

--- a/Test-Docs.ps1
+++ b/Test-Docs.ps1
@@ -20,7 +20,7 @@ Write-Host $params
 Write-Host $apiDoctor
 
 #Clone Docs Repo
-New-Item -Path $fullDocsPath -ItemType Directory
+New-Item -Path $fullDocsPath -ItemType Directory -Force
 Write-Host "Cloning Microsoft Graph Docs from Github"
 Write-Host "`tRemote URL: $graphDocsRepo"
 Write-Host "`tBranch: $graphDocsBranch"

--- a/Test-Docs.ps1
+++ b/Test-Docs.ps1
@@ -20,11 +20,11 @@ Write-Host $params
 Write-Host $apiDoctor
 
 #Clone Docs Repo
-New-Item -Path $graphDocsPath -ItemType Directory -Force
+#New-Item -Path $graphDocsPath -ItemType Directory -Force
 Write-Host "Cloning Microsoft Graph Docs from Github"
 Write-Host "`tRemote URL: $graphDocsRepo"
 Write-Host "`tBranch: $graphDocsBranch"
-$result = Invoke-Expression "git clone -b $graphDocsBranch $graphDocsRepo --recurse-submodules $fullDocsPath"
+#$result = Invoke-Expression "git clone -b $graphDocsBranch $graphDocsRepo --recurse-submodules $fullDocsPath"
 
 & $apiDoctor $params
 
@@ -32,7 +32,7 @@ $result = Invoke-Expression "git clone -b $graphDocsBranch $graphDocsRepo --recu
 if ($cleanUp -eq $true) {
    Remove-Item $graphDocsPath -Recurse -Force
 }
-Write-Host $result
+
 if ($LastExitCode -ne 0) {
     Write-Host "Errors were detected. This build failed."
     Write-Host $LastExitCode

--- a/Test-Docs.ps1
+++ b/Test-Docs.ps1
@@ -19,6 +19,9 @@ Write-Host $fullDocsSubPath
 Write-Host $params
 Write-Host $apiDoctor
 
+Test-Connection -ComputerName github.com -Count 4 -Verbose
+
+
 #Clone Docs Repo
 New-Item -Path $graphDocsPath -ItemType Directory -Force
 Write-Host "Cloning Microsoft Graph Docs from Github"
@@ -38,3 +41,4 @@ if ($LastExitCode -ne 0) {
     Write-Host $LastExitCode
     exit $LastExitCode
 }
+

--- a/Test-Docs.ps1
+++ b/Test-Docs.ps1
@@ -20,7 +20,7 @@ Write-Host $params
 Write-Host $apiDoctor
 
 #Clone Docs Repo
-New-Item -Path $fullDocsPath -ItemType Directory -Force
+New-Item -Path $graphDocsPath -ItemType Directory -Force
 Write-Host "Cloning Microsoft Graph Docs from Github"
 Write-Host "`tRemote URL: $graphDocsRepo"
 Write-Host "`tBranch: $graphDocsBranch"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,33 @@
+# .NET Desktop
+# Build and run tests for .NET Desktop or Windows classic desktop solutions.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
+
+trigger:
+- master
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: NuGetToolInstaller@0
+
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
+
+- task: VSBuild@1
+  inputs:
+    solution: '$(solution)'
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+
+- task: VSTest@2
+  inputs:
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ steps:
 - task: CmdLine@2
   displayName: "Clone Docs"
   inputs:
-    script: "git clone -b $(graphDocsBranch) https://github.com/finsharp/microsoft-graph-docs.git --recurse-submodules GraphDocs"
+    script: "git clone -b '$(graphDocsBranch)' '$(graphDocsRepo)' --recurse-submodules '$(graphDocsPath)' 2>&1 | Write-Host"
 
 - task: PowerShell@2
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: "Test-Docs.ps1"
-    arguments: -cleanUp -graphDocsPath '$(graphDocsPath)' -graphDocsRepo '$(graphDocsRepo)' -graphDocsBranch '$(graphDocsBranch)' -docSubPath '$(docSubPath)' -apiDoctorPath '$(apiDoctorPath)
+    arguments: -cleanUp -graphDocsPath '$(graphDocsPath)' -graphDocsRepo '$(graphDocsRepo)' -graphDocsBranch '$(graphDocsBranch)' -docSubPath '$(docSubPath)' -apiDoctorPath '$(apiDoctorPath)'
     #script: '# Write your powershell commands here.' # Required when targetType == Inline
     #errorActionPreference: 'stop' # Optional. Options: stop, continue, silentlyContinue
     #failOnStderr: false # Optional

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: Test-Docs.ps1
-    arguments: -cleanUp -graphDocsPath $graphDocsPath -graphDocsRepo $graphDocsRepo -graphDocsBranch $graphDocsBranch -docSubPath $docsSubPath -apiDoctorPath $apiDoctorPath
+    arguments: -cleanUp -graphDocsPath GraphDocs -graphDocsRepo $graphDocsRepo -graphDocsBranch $graphDocsBranch -docSubPath $docsSubPath -apiDoctorPath $apiDoctorPath
     #script: '# Write your powershell commands here.' # Required when targetType == Inline
     #errorActionPreference: 'stop' # Optional. Options: stop, continue, silentlyContinue
     #failOnStderr: false # Optional

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: Test-Docs.ps1
-    arguments: -cleanUp -graphDocsPath graphDocsPath -graphDocsRepo $graphDocsRepo -graphDocsBranch $graphDocsBranch -docSubPath $docsSubPath -apiDoctorPath $apiDoctorPath
+    arguments: -cleanUp -graphDocsPath $graphDocsPath -graphDocsRepo $graphDocsRepo -graphDocsBranch $graphDocsBranch -docSubPath $docsSubPath -apiDoctorPath $apiDoctorPath
     #script: '# Write your powershell commands here.' # Required when targetType == Inline
     #errorActionPreference: 'stop' # Optional. Options: stop, continue, silentlyContinue
     #failOnStderr: false # Optional

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,8 @@ steps:
     targetType: filePath
     filePath: "Test-Docs.ps1"
     arguments: -graphDocsPath '$(graphDocsPath)' -graphDocsRepo '$(graphDocsRepo)' -graphDocsBranch '$(graphDocsBranch)' -docSubPath '$(betaDocsSubPath)' -apiDoctorPath '$(apiDoctorPath)'
-
+    errorActionPreference: continue
+    
 - task: PowerShell@2
   displayName: "Run ApiDoctor Against v1.0 Docs"
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,7 @@ steps:
 - task: PowerShell@2
   displayName: "Clone Microsoft Graph Docs"
   inputs:
+    targetType: inline
     script: "git clone -b '$(graphDocsBranch)' '$(graphDocsRepo)' --recurse-submodules '$(graphDocsPath)' 2>&1 | Write-Host"
 
 - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,12 +23,15 @@ variables:
 
 steps:
 - task: NuGetToolInstaller@0
+  displayName: "Install Nuget.exe"
 
 - task: NuGetCommand@2
+  displayName: "Restore Packages for '$(solution)'"
   inputs:
     restoreSolution: '$(solution)'
 
 - task: VSBuild@1
+  displayName: "Build Solution for '$(solution)'' in '$(buildConfiguration)'"
   inputs:
     solution: '$(solution)'
     platform: '$(buildPlatform)'
@@ -49,7 +52,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: "Test-Docs.ps1"
-    arguments: -cleanUp -graphDocsPath '$(graphDocsPath)' -graphDocsRepo '$(graphDocsRepo)' -graphDocsBranch '$(graphDocsBranch)' -docSubPath '$(betaDocsSubPath)' -apiDoctorPath '$(apiDoctorPath)'
+    arguments: -graphDocsPath '$(graphDocsPath)' -graphDocsRepo '$(graphDocsRepo)' -graphDocsBranch '$(graphDocsBranch)' -docSubPath '$(betaDocsSubPath)' -apiDoctorPath '$(apiDoctorPath)'
 
 - task: PowerShell@2
   displayName: "Run ApiDoctor Against v1.0 Docs"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ variables:
   buildConfiguration: 'Release'
   graphDocsRepo: 'https://github.com/microsoftgraph/microsoft-graph-docs.git'
   graphDocsBranch: 'master'
-  docsSubPath: 'api-reference\beta'
+  docSubPath: 'api-reference\beta'
   apiDoctorPath: '$(Build.BinariesDirectory)/ApiDoctor.Console/bin/Release/apidoc.exe'
   graphDocsPath: 'GraphDocs'
   
@@ -42,7 +42,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: Test-Docs.ps1
-    arguments: -cleanUp -graphDocsPath GraphDocs -graphDocsRepo $graphDocsRepo -graphDocsBranch $graphDocsBranch -docSubPath $docsSubPath -apiDoctorPath $apiDoctorPath
+    arguments: -cleanUp -graphDocsPath '$(graphDocsPath)' -graphDocsRepo '$(graphDocsRepo)' -graphDocsBranch '$(graphDocsBranch)' -docSubPath '$(docSubPath)' -apiDoctorPath '$(apiDoctorPath)
     #script: '# Write your powershell commands here.' # Required when targetType == Inline
     #errorActionPreference: 'stop' # Optional. Options: stop, continue, silentlyContinue
     #failOnStderr: false # Optional

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,12 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
+  graphDocsRepo: 'https://github.com/microsoftgraph/microsoft-graph-docs.git'
+  graphDocsBranch: 'master'
+  docsSubPath: 'api-reference\beta'
+  apiDoctorPath: '$(Build.BinariesDirectory)/ApiDoctor.Console/bin/Release/apidoc.exe'
+  graphDocsPath: 'GraphDocs'
+  
 
 steps:
 - task: NuGetToolInstaller@0
@@ -31,3 +37,16 @@ steps:
   inputs:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+
+- task: PowerShell@2
+  inputs:
+    targetType: filePath
+    filePath: Test-Docs.ps1
+    arguments: -cleanUp -graphDocsPath graphDocsPath -graphDocsRepo $graphDocsRepo -graphDocsBranch $graphDocsBranch -docSubPath $docsSubPath -apiDoctorPath $apiDoctorPath
+    #script: '# Write your powershell commands here.' # Required when targetType == Inline
+    #errorActionPreference: 'stop' # Optional. Options: stop, continue, silentlyContinue
+    #failOnStderr: false # Optional
+    #ignoreLASTEXITCODE: false # Optional
+    #pwsh: false # Optional
+    #workingDirectory: # Optional
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
   graphDocsRepo: 'https://github.com/microsoftgraph/microsoft-graph-docs.git'
   graphDocsBranch: 'master'
   betaDocsSubPath: 'api-reference\beta'
-  v1DocsSubPath: 'api-reference\beta'
+  v1DocsSubPath: 'api-reference\v1.0'
   apiDoctorPath: '/ApiDoctor.Console/bin/Release/apidoc.exe'
   graphDocsPath: 'GraphDocs'
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
   graphDocsRepo: 'https://github.com/microsoftgraph/microsoft-graph-docs.git'
   graphDocsBranch: 'master'
   docSubPath: 'api-reference\beta'
-  apiDoctorPath: '$(System.DefaultWorkingDirectory)/ApiDoctor.Console/bin/Release/apidoc.exe'
+  apiDoctorPath: '/ApiDoctor.Console/bin/Release/apidoc.exe'
   graphDocsPath: 'GraphDocs'
   
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,11 +42,11 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
-- task: PowerShell@2
+- task: PowerShell@1
   displayName: "Clone Microsoft Graph Docs"
   inputs:
-    targetType: inline
-    script: "git clone -b '$(graphDocsBranch)' '$(graphDocsRepo)' --recurse-submodules '$(graphDocsPath)' 2>&1 | Write-Host"
+    scriptType: inlineScript
+    inlineScript: "git clone -b '$(graphDocsBranch)' '$(graphDocsRepo)' --recurse-submodules '$(graphDocsPath)' 2>&1 | Write-Host"
 
 - task: PowerShell@2
   displayName: "Run ApiDoctor Against beta Docs"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,9 +13,10 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  graphDocsRepo: 'https://github.com/finsharp/microsoft-graph-docs.git'
+  graphDocsRepo: 'https://github.com/microsoftgraph/microsoft-graph-docs.git'
   graphDocsBranch: 'master'
-  docSubPath: 'api-reference\beta'
+  betaDocsSubPath: 'api-reference\beta'
+  v1DocsSubPath: 'api-reference\beta'
   apiDoctorPath: '/ApiDoctor.Console/bin/Release/apidoc.exe'
   graphDocsPath: 'GraphDocs'
   
@@ -38,20 +39,21 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
 
-- task: CmdLine@2
-  displayName: "Clone Docs"
+- task: PowerShell@2
+  displayName: "Clone Microsoft Graph Docs"
   inputs:
     script: "git clone -b '$(graphDocsBranch)' '$(graphDocsRepo)' --recurse-submodules '$(graphDocsPath)' 2>&1 | Write-Host"
 
 - task: PowerShell@2
+  displayName: "Run ApiDoctor Against beta Docs"
   inputs:
     targetType: filePath
     filePath: "Test-Docs.ps1"
-    arguments: -cleanUp -graphDocsPath '$(graphDocsPath)' -graphDocsRepo '$(graphDocsRepo)' -graphDocsBranch '$(graphDocsBranch)' -docSubPath '$(docSubPath)' -apiDoctorPath '$(apiDoctorPath)'
-    #script: '# Write your powershell commands here.' # Required when targetType == Inline
-    #errorActionPreference: 'stop' # Optional. Options: stop, continue, silentlyContinue
-    #failOnStderr: false # Optional
-    #ignoreLASTEXITCODE: false # Optional
-    #pwsh: false # Optional
-    #workingDirectory: # Optional
+    arguments: -cleanUp -graphDocsPath '$(graphDocsPath)' -graphDocsRepo '$(graphDocsRepo)' -graphDocsBranch '$(graphDocsBranch)' -docSubPath '$(betaDocsSubPath)' -apiDoctorPath '$(apiDoctorPath)'
 
+- task: PowerShell@2
+  displayName: "Run ApiDoctor Against v1.0 Docs"
+  inputs:
+    targetType: filePath
+    filePath: "Test-Docs.ps1"
+    arguments: -cleanUp -graphDocsPath '$(graphDocsPath)' -graphDocsRepo '$(graphDocsRepo)' -graphDocsBranch '$(graphDocsBranch)' -docSubPath '$(v1DocsSubPath)' -apiDoctorPath '$(apiDoctorPath)'


### PR DESCRIPTION
All Urls should be in lowercase.

so we don't have
"GET-USER.md"
we have
"get-user.md"

Includes test to verify this.

Powershell Script enable Azure Pipelines to enable continuous testing against microsoft-graph-docs master branch.