### PR TITLE
Validate Docs against Metadata Route

### DIFF
--- a/ApiDoctor.Console/ApiDoctor.ConsoleApp.csproj
+++ b/ApiDoctor.Console/ApiDoctor.ConsoleApp.csproj
@@ -64,7 +64,7 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+    <Reference Include="CommandLine">
       <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.23.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -107,9 +107,7 @@
   <ItemGroup>
     <None Include="35MSSharedLib1024.snk" />
     <None Include="App.config" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ApiDoctor.DocumentationGeneration\ApiDoctor.DocumentationGeneration.csproj">

--- a/ApiDoctor.Console/ApiDoctor.ConsoleApp.csproj
+++ b/ApiDoctor.Console/ApiDoctor.ConsoleApp.csproj
@@ -64,25 +64,29 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine">
+    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
       <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.23.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.23.302261847\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.23.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.23.302261847\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.23.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.23.302261847\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.23.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.23.302261847\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppVeyor\BuildWorkerApi.cs" />
@@ -103,7 +107,9 @@
   <ItemGroup>
     <None Include="35MSSharedLib1024.snk" />
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ApiDoctor.DocumentationGeneration\ApiDoctor.DocumentationGeneration.csproj">

--- a/ApiDoctor.Console/ApiDoctor.ConsoleApp.csproj
+++ b/ApiDoctor.Console/ApiDoctor.ConsoleApp.csproj
@@ -78,10 +78,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -1860,10 +1860,10 @@ namespace ApiDoctor.ConsoleApp
                     continue;
                 }
 
-                var shouldValidateNameSpace = metadataValidationConfigs?.ModelConfigs?.ValidateNamespace;
+                var modelConfigs = metadataValidationConfigs?.ModelConfigs;
                 var documentedResources = docSet.Resources;
 
-                ResourceDefinition resourceDocumentation = GetResoureDocumentation(resource, documentedResources, shouldValidateNameSpace);
+                ResourceDefinition resourceDocumentation = GetResoureDocumentation(resource, documentedResources, modelConfigs?.ValidateNamespace);
 
                 if (null == resourceDocumentation)
                 {
@@ -1876,7 +1876,17 @@ namespace ApiDoctor.ConsoleApp
                 else
                 {
                     // Verify that this resource matches the documentation
-                    docSet.ResourceCollection.ValidateJsonExample(resource.OriginalMetadata, resource.ExampleText, resourceIssues, new ValidationOptions { RelaxedStringValidation = true, IgnorablePropertyTypes = metadataValidationConfigs?.IgnorableModels, AllowTruncatedResponses = true });
+                    docSet.ResourceCollection.ValidateJsonExample(
+                        resource.OriginalMetadata,
+                        resource.ExampleText,
+                        resourceIssues,
+                        new ValidationOptions
+                        {
+                            RelaxedStringValidation = true,
+                            IgnorablePropertyTypes = metadataValidationConfigs?.IgnorableModels,
+                            AllowTruncatedResponses = modelConfigs?.SkipProprtiesValidation ?? false
+                        }
+                    );
                 }
 
                 results.IncrementResultCount(resourceIssues.Issues);

--- a/ApiDoctor.Console/packages.config
+++ b/ApiDoctor.Console/packages.config
@@ -3,4 +3,5 @@
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.23.302261847" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net45" />
 </packages>

--- a/ApiDoctor.Console/packages.config
+++ b/ApiDoctor.Console/packages.config
@@ -3,5 +3,4 @@
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.23.302261847" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="System.Net.Http" version="4.3.4" targetFramework="net45" />
 </packages>

--- a/ApiDoctor.DocumentationGeneration/ApiDoctor.DocumentationGeneration.csproj
+++ b/ApiDoctor.DocumentationGeneration/ApiDoctor.DocumentationGeneration.csproj
@@ -37,7 +37,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ApiDoctor.Publishing/ApiDoctor.Publishing.csproj
+++ b/ApiDoctor.Publishing/ApiDoctor.Publishing.csproj
@@ -32,7 +32,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/ApiDoctor.Validation.UnitTests/ApiDoctor.Validation.UnitTests.csproj
+++ b/ApiDoctor.Validation.UnitTests/ApiDoctor.Validation.UnitTests.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
@@ -46,9 +49,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BrokenLinkTests.cs" />

--- a/ApiDoctor.Validation/ApiDoctor.Validation.csproj
+++ b/ApiDoctor.Validation/ApiDoctor.Validation.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -41,15 +44,13 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AuthenicationCredentials.cs" />
     <Compile Include="AuthScopeDefinition.cs" />
     <Compile Include="CodeBlockAnnotation.cs" />
+    <Compile Include="Config\MetadataValidationConfigFile.cs" />
     <Compile Include="Config\DocumentOutlineFile.cs" />
     <Compile Include="Config\LinkValidationConfigFile.cs" />
     <Compile Include="DocFile.cs" />

--- a/ApiDoctor.Validation/Config/MetadataValidationConfigFile.cs
+++ b/ApiDoctor.Validation/Config/MetadataValidationConfigFile.cs
@@ -1,0 +1,67 @@
+﻿/*
+ * API Doctor
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved. 
+ * 
+ * MIT License
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of 
+ * this software and associated documentation files (the ""Software""), to deal in 
+ * the Software without restriction, including without limitation the rights to use, 
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so, 
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all 
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION 
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace ApiDoctor.Validation.Config
+{
+    using Newtonsoft.Json;
+
+    public class MetadataValidationConfigFile : ConfigFile
+    {
+        [JsonProperty("metadata-validation-configs")]
+        public MetadataValidationConfigs MetadataValidationConfigs { get;set;}
+
+        public override bool IsValid
+        {
+            get
+            {
+                return this.MetadataValidationConfigs != null;
+            }
+        }
+    }
+
+    public class MetadataValidationConfigs
+    {
+        [JsonProperty("modelConfigs")]
+        public ModelConfigs ModelConfigs { get;set;}
+
+        [JsonProperty("ignorableModels")]
+        public string[] IgnorableModels { get; set; }
+
+    }
+
+    public class ModelConfigs
+    {
+        [JsonProperty("validateNamespace")]
+        public bool ValidateNamespace { get;set;}
+
+        [JsonProperty("aliasNamespace")]
+        public string AliasNamespace { get; set; }
+
+        [JsonProperty("skipProprtiesValidation")]
+        public bool SkipProprtiesValidation { get; set; }
+    }
+
+}
+

--- a/ApiDoctor.Validation/DocSet.cs
+++ b/ApiDoctor.Validation/DocSet.cs
@@ -94,6 +94,8 @@ namespace ApiDoctor.Validation
 
         public ApiRequirements Requirements { get; internal set; }
 
+        public MetadataValidationConfigs MetadataValidationConfigs { get; internal set; }
+
         public DocumentOutlineFile DocumentStructure { get; internal set; }
 
         public LinkValidationConfigFile LinkValidationConfig { get; private set; }
@@ -138,6 +140,14 @@ namespace ApiDoctor.Validation
             {
                 Console.WriteLine("Using API requirements file: {0}", foundRequirements.SourcePath);
                 this.Requirements = foundRequirements.ApiRequirements;
+            }
+
+            MetadataValidationConfigFile[] documentsValidationConfigs = TryLoadConfigurationFiles<MetadataValidationConfigFile>(this.SourceFolderPath);
+            var foundDocsconfigs = documentsValidationConfigs.FirstOrDefault();
+            if (null != foundDocsconfigs)
+            {
+                Console.WriteLine("Using Documents validation config file: {0}", foundDocsconfigs.SourcePath);
+                this.MetadataValidationConfigs = foundDocsconfigs.MetadataValidationConfigs;
             }
 
             DocumentOutlineFile[] outlines = TryLoadConfigurationFiles<DocumentOutlineFile>(this.SourceFolderPath);

--- a/ApiDoctor.Validation/Json/JsonSchema.cs
+++ b/ApiDoctor.Validation/Json/JsonSchema.cs
@@ -27,7 +27,6 @@ namespace ApiDoctor.Validation.Json
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
     using ApiDoctor.Validation.Error;
@@ -391,10 +390,6 @@ namespace ApiDoctor.Validation.Json
         /// </summary>
         private PropertyValidationOutcome ValidateProperty(ParameterDefinition inputProperty, Dictionary<string, JsonSchema> schemas, IssueLogger issues, ValidationOptions options)
         {
-            //if (inputProperty.Name == "sendInvitationStatus")
-            //{
-            //    Debugger.Launch();
-            //}
             if (this.ExpectedProperties.ContainsKey(inputProperty.Name))
             {
                 // The property was expected to be found in this schema! Yay.
@@ -489,13 +484,6 @@ namespace ApiDoctor.Validation.Json
             }
             else
             {
-                // Debugger.Launch();
-                // This else only get hits for "@Odata.type" property, and it will be skipped by this "fake" ignorableUndocumentedProperties which is in
-                // C:\Git\apidocs\docs\rest-api\config\oneapi-design-v1.json - ignorableProperties
-
-                // It's funny that only this branch has "UndocumentedPropertyWarning" result, the previous if only check for the "type" of property.
-
-
                 // Check to see if this property is on the ignorable list
                 string[] ignorableUndocumentedProperties = this.OriginalResource?.SourceFile.Parent.Requirements?.IgnorableProperties;
 

--- a/ApiDoctor.Validation/Json/ValidationOptions.cs
+++ b/ApiDoctor.Validation/Json/ValidationOptions.cs
@@ -69,6 +69,11 @@ namespace ApiDoctor.Validation.Json
         public string[] RequiredPropertyNames { get; set; }
 
         /// <summary>
+        /// A list of models types that we don't need to validate.
+        /// </summary>
+        public string[] IgnorablePropertyTypes { get; set; }
+
+        /// <summary>
         /// For collection results, what is the name of the property that 
         /// includes the collection. Defaults to 'value'.
         /// </summary>

--- a/ApiDoctor.Validation/Json/ValidationOptions.cs
+++ b/ApiDoctor.Validation/Json/ValidationOptions.cs
@@ -69,7 +69,9 @@ namespace ApiDoctor.Validation.Json
         public string[] RequiredPropertyNames { get; set; }
 
         /// <summary>
-        /// A list of models types that we don't need to validate.
+        /// A list of models types that we don't need to validate. 
+        /// If the type of the model doesn't exist,
+        /// we don't need to validate the model properties.
         /// </summary>
         public string[] IgnorablePropertyTypes { get; set; }
 

--- a/ApiDoctor.Validation/Json/jsonresourcecollection.cs
+++ b/ApiDoctor.Validation/Json/jsonresourcecollection.cs
@@ -193,9 +193,11 @@ namespace ApiDoctor.Validation.Json
             }
 
             // If we didn't get an options, create a new one with some defaults provided by the annotation
-            options = options ?? new ValidationOptions();
-            options.AllowTruncatedResponses = (inputJson.Annotation ?? new CodeBlockAnnotation()).TruncatedResult;
-            options.CollectionPropertyName = collectionPropertyName;
+            options = options ?? new ValidationOptions()
+            {
+                AllowTruncatedResponses = (inputJson.Annotation ?? new CodeBlockAnnotation()).TruncatedResult,
+                CollectionPropertyName = collectionPropertyName
+            };
 
             return schema.ValidateJson(inputJson, issues, this.registeredSchema, options, expectedJson);
         }

--- a/ApiDoctor.Validation/Json/jsonresourcecollection.cs
+++ b/ApiDoctor.Validation/Json/jsonresourcecollection.cs
@@ -196,9 +196,7 @@ namespace ApiDoctor.Validation.Json
             options = options ?? new ValidationOptions();
 
             var annotationTruncated = (inputJson.Annotation ?? new CodeBlockAnnotation()).TruncatedResult;
-            options.AllowTruncatedResponses = annotationTruncated
-                ? annotationTruncated
-                : options.AllowTruncatedResponses;
+            options.AllowTruncatedResponses = annotationTruncated || options.AllowTruncatedResponses;
             options.CollectionPropertyName = collectionPropertyName;
 
             return schema.ValidateJson(inputJson, issues, this.registeredSchema, options, expectedJson);

--- a/ApiDoctor.Validation/Json/jsonresourcecollection.cs
+++ b/ApiDoctor.Validation/Json/jsonresourcecollection.cs
@@ -193,11 +193,13 @@ namespace ApiDoctor.Validation.Json
             }
 
             // If we didn't get an options, create a new one with some defaults provided by the annotation
-            options = options ?? new ValidationOptions()
-            {
-                AllowTruncatedResponses = (inputJson.Annotation ?? new CodeBlockAnnotation()).TruncatedResult,
-                CollectionPropertyName = collectionPropertyName
-            };
+            options = options ?? new ValidationOptions();
+
+            var annotationTruncated = (inputJson.Annotation ?? new CodeBlockAnnotation()).TruncatedResult;
+            options.AllowTruncatedResponses = annotationTruncated
+                ? annotationTruncated
+                : options.AllowTruncatedResponses;
+            options.CollectionPropertyName = collectionPropertyName;
 
             return schema.ValidateJson(inputJson, issues, this.registeredSchema, options, expectedJson);
         }


### PR DESCRIPTION
- Cleaned up and Enhanced "CheckMetadataOptions" Route to support multiple useful scenarios, and a world where not everything is perfect aka documented.

- There shouldn't be any breaking changes to the current flow of the route. There was a minor change to the flow in (ApiDoctor.Validation/Json/jsonresourcecollection.cs) where it seemed to be either a bug/typo or poor design to always overwrite options.