### PR TITLE
Enforce document structure

### DIFF
--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -332,7 +332,7 @@ namespace ApiDoctor.ConsoleApp
             DateTimeOffset end = DateTimeOffset.Now;
             TimeSpan duration = end.Subtract(start);
 
-            FancyConsole.WriteLine($"Took {duration.TotalSeconds} to parse {set.Files.Length} source files.");
+            FancyConsole.WriteLine($"Took {duration.TotalSeconds}s to parse {set.Files.Length} source files.");
             return Task.FromResult<DocSet>(set);
         }
 

--- a/ApiDoctor.Validation/Config/ConfigFile.cs
+++ b/ApiDoctor.Validation/Config/ConfigFile.cs
@@ -31,7 +31,7 @@ namespace ApiDoctor.Validation.Config
         public string SourcePath { get; set; }
 
         /// <summary>
-        /// Provide oppertunity to post-process a valid configuration after the file is loaded.
+        /// Provide opportunity to post-process a valid configuration after the file is loaded.
         /// </summary>
         public virtual void LoadComplete()
         {

--- a/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
+++ b/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
@@ -141,6 +141,22 @@ namespace ApiDoctor.Validation.Config
         [JsonProperty("headers"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
         public new List<object> ChildHeaders { get; set; }
 
+        public ExpectedHeader Clone()
+        {
+            var header = (ExpectedHeader)this.MemberwiseClone();
+            List<object> childHeaders = new List<object>();
+            foreach (var childHeader in this.ChildHeaders)
+            {
+                if (childHeader is ExpectedHeader)
+                {
+                    childHeaders.Add(((ExpectedHeader)childHeader).Clone());
+                    continue;
+                }
+                childHeaders.Add(((ConditionalHeader)childHeader).Clone());
+            }
+            header.ChildHeaders = childHeaders;
+            return header;
+        }
     }
 
     public class ConditionalHeader
@@ -158,6 +174,23 @@ namespace ApiDoctor.Validation.Config
                 ConditionalOperator op;
                 return Enum.TryParse(this.Condition, true, out op) ? op : (ConditionalOperator?)null;
             }
+        }
+
+        public ConditionalHeader Clone()
+        {
+            var header = (ConditionalHeader)this.MemberwiseClone();
+            List<object> arguments = new List<object>();
+            foreach (var arg in this.Arguments)
+            {
+                if (arg is ExpectedHeader)
+                {
+                    arguments.Add(((ExpectedHeader)arg).Clone());
+                    continue;
+                }
+                arguments.Add(((ConditionalHeader)arg).Clone());
+            }
+            header.Arguments = arguments;
+            return header;
         }
     }
 

--- a/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
+++ b/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
@@ -182,7 +182,7 @@ namespace ApiDoctor.Validation.Config
                     }
 
                     // Object is neither of type ExpectedHeader nor ConditionalHeader
-                    throw new JsonReaderException($"Invalid document header definition: {item.First}");
+                    throw new JsonReaderException("Invalid document header definition");
                 }
                 return expectedHeaders;
             }

--- a/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
+++ b/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
@@ -34,18 +34,26 @@ namespace ApiDoctor.Validation.Config
     public class DocumentOutlineFile : ConfigFile
     {
         [JsonProperty("apiPageType"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
-        public List<object> ApiPageType { get; set; } = new List<object>();
+        public List<object> ApiPageType { get; set; }
 
         [JsonProperty("resourcePageType"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
-        public List<object> ResourcePageType { get; set; } = new List<object>();
+        public List<object> ResourcePageType { get; set; }
 
         [JsonProperty("conceptualPageType"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
-        public List<object> ConceptualPageType { get; set; } = new List<object>();
+        public List<object> ConceptualPageType { get; set; }
 
         [JsonProperty("enumPageType"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
-        public List<object> EnumPageType { get; set; } = new List<object>();
+        public List<object> EnumPageType { get; set; }
 
         public override bool IsValid => this.ApiPageType.Any() || this.ResourcePageType.Any() || this.ConceptualPageType.Any() || this.EnumPageType.Any();
+
+        public DocumentOutlineFile()
+        {
+            ApiPageType = new List<object>();
+            ResourcePageType = new List<object>();
+            ConceptualPageType = new List<object>();
+            EnumPageType = new List<object>();
+        }
     }
 
     public class DocumentHeader

--- a/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
+++ b/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
@@ -80,17 +80,21 @@ namespace ApiDoctor.Validation.Config
         [JsonProperty("headers")]
         public List<DocumentHeader> ChildHeaders { get; set; }
 
-        internal bool Matches(DocumentHeader found)
+        internal bool Matches(DocumentHeader found, bool ignoreCase = false)
         {
-            return this.Level == found.Level && DoTitlesMatch(this.Title, found.Title);
+            return this.Level == found.Level && DoTitlesMatch(this.Title, found.Title, ignoreCase);
         }
 
-        private static bool DoTitlesMatch(string expectedTitle, string foundTitle)
+        private static bool DoTitlesMatch(string expectedTitle, string foundTitle, bool ignoreCase)
         {
-            if (expectedTitle == foundTitle) return true;
+            StringComparison comparisonType = StringComparison.Ordinal;
+            if (ignoreCase) comparisonType = StringComparison.OrdinalIgnoreCase;
+
+            if (expectedTitle.Equals(foundTitle, comparisonType))
+                return true;
             if (string.IsNullOrEmpty(expectedTitle) || expectedTitle == "*") return true;
-            if (expectedTitle.StartsWith("* ") && foundTitle.EndsWith(expectedTitle.Substring(2))) return true;
-            if (expectedTitle.EndsWith(" *") && foundTitle.StartsWith(expectedTitle.Substring(0, expectedTitle.Length - 2))) return true;
+            if (expectedTitle.StartsWith("* ") && foundTitle.EndsWith(expectedTitle.Substring(2), comparisonType)) return true;
+            if (expectedTitle.EndsWith(" *") && foundTitle.StartsWith(expectedTitle.Substring(0, expectedTitle.Length - 2), comparisonType)) return true;
             return false;
         }
 

--- a/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
+++ b/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
@@ -26,21 +26,26 @@
 namespace ApiDoctor.Validation.Config
 {
     using System;
+    using System.Linq;
     using System.Collections.Generic;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
     public class DocumentOutlineFile : ConfigFile
     {
-        [JsonProperty("allowedDocumentHeaders")]
-        public DocumentHeader[] AllowedHeaders { get; set; }
+        [JsonProperty("apiPageType"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
+        public List<object> ApiPageType { get; set; } = new List<object>();
 
-        public override bool IsValid
-        {
-            get
-            {
-                return this.AllowedHeaders != null;
-            }
-        }
+        [JsonProperty("resourcePageType"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
+        public List<object> ResourcePageType { get; set; } = new List<object>();
+
+        [JsonProperty("conceptualPageType"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
+        public List<object> ConceptualPageType { get; set; } = new List<object>();
+
+        [JsonProperty("enumPageType"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
+        public List<object> EnumPageType { get; set; } = new List<object>();
+
+        public override bool IsValid => this.ApiPageType.Any() || this.ResourcePageType.Any() || this.ConceptualPageType.Any() || this.EnumPageType.Any();
     }
 
     public class DocumentHeader
@@ -88,6 +93,129 @@ namespace ApiDoctor.Validation.Config
             if (expectedTitle.EndsWith(" *") && foundTitle.StartsWith(expectedTitle.Substring(0, expectedTitle.Length - 2))) return true;
             return false;
         }
+
+        public override string ToString()
+        {
+            return this.Title;
+        }
     }
 
+    public class ExpectedHeader : DocumentHeader
+    {
+        public ExpectedHeader()
+        {
+            Level = 1;
+            ChildHeaders = new List<object>();
+        }
+
+        /// <summary>
+        /// Indicates that a header pattern can be repeated multiple times e.g. in the case of multiple examples
+        /// </summary>
+        [JsonProperty("multiple")]
+        public bool Multiple { get; set; }
+
+        /// <summary>
+        /// Specifies the headers that are allowed under this header.
+        /// </summary>
+        [JsonProperty("headers"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
+        public new List<object> ChildHeaders { get; set; }
+
+    }
+
+    public class ConditionalHeader
+    {
+        [JsonProperty("condition")]
+        public string Condition { get; set; }
+
+        [JsonProperty("arguments"), JsonConverter(typeof(DocumentHeaderJsonConverter))]
+        public List<object> Arguments { get; set; }
+
+        public ConditionalOperator? Operator
+        {
+            get
+            {
+                ConditionalOperator op;
+                return Enum.TryParse(this.Condition, true, out op) ? op : (ConditionalOperator?)null;
+            }
+        }
+    }
+
+    public enum ConditionalOperator
+    {
+        OR,
+        AND
+    }
+
+    public class DocumentHeaderJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartArray)
+            {
+                var jArray = JArray.Load(reader);
+                List<object> expectedHeaders = new List<object>();
+                foreach (var item in jArray)
+                {
+                    ConditionalHeader conditionalHeader;
+                    bool isConditionalHeader = item.ToString().TryParseJson(out conditionalHeader);
+                    if (isConditionalHeader)
+                    {
+                        expectedHeaders.Add(conditionalHeader);
+                        continue;
+                    }
+
+                    ExpectedHeader header;
+                    bool isExpectedHeader = item.ToString().TryParseJson(out header);
+                    if (isExpectedHeader)
+                    {
+                        expectedHeaders.Add(header);
+                        continue;
+                    }
+
+                    // Object is neither of type ExpectedHeader nor ConditionalHeader
+                    throw new JsonReaderException($"Invalid document header definition: {item.First}");
+                }
+                return expectedHeaders;
+            }
+            else if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObject = JObject.Load(reader);
+
+                ConditionalHeader conditionalHeader;
+                bool isConditionalHeader = jObject.ToString().TryParseJson(out conditionalHeader);
+                if (isConditionalHeader)
+                {
+                    return conditionalHeader;
+                }
+
+                ExpectedHeader header;
+                bool isExpectedHeader = jObject.ToString().TryParseJson(out header);
+                if (isExpectedHeader)
+                {
+                    return header;
+                }
+
+                // Object is neither of type ExpectedHeader nor ConditionalHeader
+                throw new JsonReaderException($"Invalid document header definition: {jObject.ToString()}");
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                throw new JsonSerializationException($"Unexpected token: {existingValue}");
+            }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return false;
+        }
+    }
 }

--- a/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
+++ b/ApiDoctor.Validation/Config/DocumentOutlineFile.cs
@@ -80,8 +80,13 @@ namespace ApiDoctor.Validation.Config
         [JsonProperty("headers")]
         public List<DocumentHeader> ChildHeaders { get; set; }
 
-        internal bool Matches(DocumentHeader found, bool ignoreCase = false)
+        internal bool Matches(DocumentHeader found, bool ignoreCase = false, bool checkStringDistance = false)
         {
+            if (checkStringDistance)
+            {
+                return IsMisspelt(found);
+            }
+
             return this.Level == found.Level && DoTitlesMatch(this.Title, found.Title, ignoreCase);
         }
 
@@ -96,6 +101,10 @@ namespace ApiDoctor.Validation.Config
             if (expectedTitle.StartsWith("* ") && foundTitle.EndsWith(expectedTitle.Substring(2), comparisonType)) return true;
             if (expectedTitle.EndsWith(" *") && foundTitle.StartsWith(expectedTitle.Substring(0, expectedTitle.Length - 2), comparisonType)) return true;
             return false;
+        }
+        internal bool IsMisspelt(DocumentHeader found)
+        {
+            return this.Level == found.Level && this.Title.StringDistance(found.Title) < 5;
         }
 
         public override string ToString()

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -196,7 +196,7 @@ namespace ApiDoctor.Validation
         protected DocFile()
         {
             this.ContentOutline = new List<string>();
-            this.DocumentHeaders = new List<Config.DocumentHeader>();
+            this.DocumentHeaders = new List<DocumentHeader>();
         }
 
         public DocFile(string basePath, string relativePath, DocSet parent)
@@ -206,7 +206,7 @@ namespace ApiDoctor.Validation
             this.FullPath = Path.Combine(basePath, relativePath.Substring(1));
             this.DisplayName = relativePath;
             this.Parent = parent;
-            this.DocumentHeaders = new List<Config.DocumentHeader>();
+            this.DocumentHeaders = new List<DocumentHeader>();
         }
 
         #endregion
@@ -678,18 +678,18 @@ namespace ApiDoctor.Validation
         public void SetExpectedDocumentHeaders()
         {
             var documentOutline = this.Parent.DocumentStructure;
-            switch (this.DocType)
+            switch (this.DocumentPageType)
             {
-                case DocumentType.ApiPageType:
+                case PageType.ApiPageType:
                     this.ExpectedDocumentHeaders = documentOutline.ApiPageType;
                     break;
-                case DocumentType.ResourcePageType:
+                case PageType.ResourcePageType:
                     this.ExpectedDocumentHeaders = documentOutline.ResourcePageType;
                     break;
-                case DocumentType.EnumPageType:
+                case PageType.EnumPageType:
                     this.ExpectedDocumentHeaders = documentOutline.EnumPageType;
                     break;
-                case DocumentType.ConceptualPageType:
+                case PageType.ConceptualPageType:
                     this.ExpectedDocumentHeaders = documentOutline.ConceptualPageType;
                     break;
                 default:

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -680,6 +680,22 @@ namespace ApiDoctor.Validation
             return issues.Issues.All(x => !x.IsError);
         }
 
+        public List<object> CopyDocumentHeaders(List<object> headers)
+        {
+            var newHeaders = new List<object>();
+
+            foreach (var header in headers)
+            {
+                if (header is ExpectedHeader)
+                {
+                    newHeaders.Add(((ExpectedHeader)header).Clone());
+                    continue;
+                }
+                newHeaders.Add(((ConditionalHeader)header).Clone());
+            }
+            return newHeaders;
+        }
+
         /// <summary>
         /// Set expected headers for doc file based on the document type as specified in YAML metadata
         /// </summary>
@@ -690,16 +706,16 @@ namespace ApiDoctor.Validation
             switch (this.DocumentPageType)
             {
                 case PageType.ApiPageType:
-                    this.ExpectedDocumentHeaders = documentOutline.ApiPageType;
+                    this.ExpectedDocumentHeaders = CopyDocumentHeaders(documentOutline.ApiPageType);
                     break;
                 case PageType.ResourcePageType:
-                    this.ExpectedDocumentHeaders = documentOutline.ResourcePageType;
+                    this.ExpectedDocumentHeaders = CopyDocumentHeaders(documentOutline.ResourcePageType);
                     break;
                 case PageType.EnumPageType:
-                    this.ExpectedDocumentHeaders = documentOutline.EnumPageType;
+                    this.ExpectedDocumentHeaders = CopyDocumentHeaders(documentOutline.EnumPageType);
                     break;
                 case PageType.ConceptualPageType:
-                    this.ExpectedDocumentHeaders = documentOutline.ConceptualPageType;
+                    this.ExpectedDocumentHeaders = CopyDocumentHeaders(documentOutline.ConceptualPageType);
                     break;
                 default:
                     this.ExpectedDocumentHeaders = new List<object>();

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -763,7 +763,7 @@ namespace ApiDoctor.Validation
                     {
                         if (multiplesFound == 1)
                         {
-                            issues.Error(ValidationErrorCode.DocumentHeaderInWrongCase, $"Multiple headers expected but only one was found: {found.Title}");
+                            issues.Warning(ValidationErrorCode.DocumentHeaderInWrongCase, $"Multiple headers expected but only one was found: {found.Title}");
                         }
 
                         if (multiplesFound > 0)

--- a/ApiDoctor.Validation/DocSet.cs
+++ b/ApiDoctor.Validation/DocSet.cs
@@ -97,7 +97,7 @@ namespace ApiDoctor.Validation
 
         public MetadataValidationConfigs MetadataValidationConfigs { get; internal set; }
 
-        public DocumentOutlineFile DocumentStructure { get; internal set; }
+        public DocumentOutlineFile DocumentStructure { get; internal set; } = new DocumentOutlineFile();
 
         public LinkValidationConfigFile LinkValidationConfig { get; private set; }
 

--- a/ApiDoctor.Validation/DocSet.cs
+++ b/ApiDoctor.Validation/DocSet.cs
@@ -161,6 +161,10 @@ namespace ApiDoctor.Validation
                 Console.WriteLine("Using document structure file: {0}", foundOutlines.SourcePath);
                 this.DocumentStructure = foundOutlines;
             }
+            else
+            {
+                Console.WriteLine("Document structure file has been incorrectly formatted or is missing");
+            }
 
             LinkValidationConfigFile[] linkConfigs = TryLoadConfigurationFiles<LinkValidationConfigFile>(this.SourceFolderPath);
             var foundLinkConfig = linkConfigs.FirstOrDefault();

--- a/ApiDoctor.Validation/Error/validationerror.cs
+++ b/ApiDoctor.Validation/Error/validationerror.cs
@@ -99,6 +99,7 @@ namespace ApiDoctor.Validation.Error
         MissingHeaderBlock,
         InvalidDateTimeString,
         InvalidEnumeratedValueString,
+        InvalidYamlFrontMatter,
         InvalidUrlString,
         InvalidExpectationKey,
         ExpectationConditionFailed,

--- a/ApiDoctor.Validation/Error/validationerror.cs
+++ b/ApiDoctor.Validation/Error/validationerror.cs
@@ -115,6 +115,7 @@ namespace ApiDoctor.Validation.Error
         RequiredDocumentHeaderMissing,
         DocumentHeaderInWrongPosition,
         DocumentHeaderInWrongCase,
+        MisspeltDocumentHeader,
         RequiredYamlHeaderMissing,
         IncorrectYamlHeaderFormat,
         SkippedSimilarErrors,

--- a/ApiDoctor.Validation/Error/validationerror.cs
+++ b/ApiDoctor.Validation/Error/validationerror.cs
@@ -114,6 +114,7 @@ namespace ApiDoctor.Validation.Error
         ExtraDocumentHeaderFound,
         RequiredDocumentHeaderMissing,
         DocumentHeaderInWrongPosition,
+        DocumentHeaderInWrongCase,
         RequiredYamlHeaderMissing,
         IncorrectYamlHeaderFormat,
         SkippedSimilarErrors,

--- a/ApiDoctor.Validation/ExtensionMethods.cs
+++ b/ApiDoctor.Validation/ExtensionMethods.cs
@@ -573,7 +573,43 @@ namespace ApiDoctor.Validation
                     return false;
             }
         }
+        /// <summary>
+        /// Uses the Damerau-Levenshtein distance algorithm which calculates how different one string is from another 
+        /// </summary>
+        /// <param name="s"></param>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        public static int StringDistance(this string s, string t)
+        {
+            var bounds = new { Height = s.Length + 1, Width = t.Length + 1 };
 
+            int[,] matrix = new int[bounds.Height, bounds.Width];
+
+            for (int height = 0; height < bounds.Height; height++) { matrix[height, 0] = height; };
+            for (int width = 0; width < bounds.Width; width++) { matrix[0, width] = width; };
+
+            for (int height = 1; height < bounds.Height; height++)
+            {
+                for (int width = 1; width < bounds.Width; width++)
+                {
+                    int cost = (s[height - 1] == t[width - 1]) ? 0 : 1;
+                    int insertion = matrix[height, width - 1] + 1;
+                    int deletion = matrix[height - 1, width] + 1;
+                    int substitution = matrix[height - 1, width - 1] + cost;
+
+                    int distance = Math.Min(insertion, Math.Min(deletion, substitution));
+
+                    if (height > 1 && width > 1 && s[height - 1] == t[width - 2] && s[height - 2] == t[width - 1])
+                    {
+                        distance = Math.Min(distance, matrix[height - 2, width - 2] + cost);
+                    }
+
+                    matrix[height, width] = distance;
+                }
+            }
+
+            return matrix[bounds.Height - 1, bounds.Width - 1];
+        }
 
         public static void SplitUrlComponents(this string inputUrl, out string path, out string queryString)
         {

--- a/ApiDoctor.Validation/ExtensionMethods.cs
+++ b/ApiDoctor.Validation/ExtensionMethods.cs
@@ -28,15 +28,15 @@ namespace ApiDoctor.Validation
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Text;
     using System.Text.RegularExpressions;
-    using ApiDoctor.Validation.Error;
-    using ApiDoctor.Validation.Json;
     using MarkdownDeep;
+    using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
-    using System.Globalization;
+    using ApiDoctor.Validation.Error;
     using ApiDoctor.Validation.OData.Transformation;
 
     public static class ExtensionMethods
@@ -789,6 +789,23 @@ namespace ApiDoctor.Validation
             }
 
             return null;
+        }
+
+        public static bool TryParseJson<T>(this string obj, out T result)
+        {
+            try
+            {
+                JsonSerializerSettings settings = new JsonSerializerSettings();
+                settings.MissingMemberHandling = MissingMemberHandling.Error;
+
+                result = JsonConvert.DeserializeObject<T>(obj, settings);
+                return true;
+            }
+            catch (Exception)
+            {
+                result = default(T);
+                return false;
+            }
         }
 
         /// <summary>

--- a/ApiDoctor.Validation/Tags/TagProcessor.cs
+++ b/ApiDoctor.Validation/Tags/TagProcessor.cs
@@ -26,11 +26,10 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
+using ApiDoctor.Validation;
 using ApiDoctor.Validation.Error;
 using System.Text.RegularExpressions;
 using MarkdownDeep;
-using System.Collections.Generic;
 
 namespace ApiDoctor.Validation.Tags
 {


### PR DESCRIPTION
Validate document outline based on api page type.

Document outline config is in the below format:

```{
  "apiPageType": [
    {
      "title": "",
      "level": 1,
      "required": true,
      "headers": [
        {
          "title": "Permissions",
          "level": 2,
          "required": true
        },
        {
          "title": "HTTP request",
          "level": 2,
          "required": true
        },
        {
          "title": "Path parameters",
          "level": 2,
          "required": false
        },
        {
          "title": "Function parameters",
          "level": 2,
          "required": false
        },
        {
          "condition": "OR",
          "arguments": [
            {
              "title": "Query parameters",
              "level": 2,
              "required": false,
              "headers": [
                {
                  "title": "OData query parameters",
                  "level": 3,
                  "required": false
                }
              ]
            },
            {
              "title": "Optional query parameters",
              "level": 2,
              "required": false
            }
          ]
        },
        {
          "title": "Request headers",
          "level": 2,
          "required": true
        },
        {
          "title": "Request body",
          "level": 2,
          "required": true
        },
        {
          "title": "Response",
          "level": 2,
          "required": true
        },
        {
          "title": "Examples",
          "level": 2,
          "required": true,
          "headers": [
            {
              "condition": "OR",
              "arguments": [
                {
                  "title": "Example *",
                  "level": 3,
                  "multiple": true,
                  "required": true,
                  "headers": [
                    {
                      "title": "Request",
                      "level": 4,
                      "required": true
                    },
                    {
                      "title": "Response",
                      "level": 4,
                      "required": true
                    }
                  ]
                },
                {
                  "condition": "AND",
                  "arguments": [
                    {
                      "title": "Request",
                      "level": 3,
                      "required": true
                    },
                    {
                      "title": "Response",
                      "level": 3,
                      "required": true
                    }
                  ]
                }
              ]
            }
          ]
        },
        {
          "title": "See also",
          "level": 2,
          "required": false
        }
      ]
    }
  ],
  "resourcePageType": [
    {
      "title": "* resource type",
      "level": 1,
      "required": true,
      "headers": [
        {
          "title": "Methods",
          "level": 2,
          "required": false
        },
        {
          "title": "Properties",
          "level": 2,
          "required": true
        },
        {
          "title": "Relationships",
          "level": 2,
          "required": false
        },
        {
          "title": "JSON representation",
          "level": 2,
          "required": true
        },
        {
          "title": "See also",
          "level": 2,
          "required": false
        }
      ]
    }
  ],
  "enumPageType": [
    {
      "title": "* enum type",
      "level": 1,
      "required": true,
      "headers": [
        {
          "title": "Members",
          "level": 2,
          "required": true
        }
      ]
    }
  ]
}
```

