### PR TITLE
Infer namespace from resource

### DIFF
--- a/ApiDoctor.Validation/ParameterDefinition.cs
+++ b/ApiDoctor.Validation/ParameterDefinition.cs
@@ -147,6 +147,8 @@ namespace ApiDoctor.Validation
                         issues.Warning(ValidationErrorCode.ExpectedTypeDifferent,
                             $"Type mismatch between example and table. Parameter name: { this.Name}; example type: ({ this.Type.CustomTypeName}); table type: ({ param.Type.CustomTypeName})");
                     }
+                    // table should be authoritative.
+                    this.Type = param.Type;
                 }
                 else if (this.Type.IsCollection)
                 {


### PR DESCRIPTION
Infer namespace from resource to remove need for specifying namespace in page annotation for resource topics
Validate object property types against resource names
