### PR TITLE
Base type should not be empty

### DIFF
--- a/ApiDoctor.Validation/DocSet.cs
+++ b/ApiDoctor.Validation/DocSet.cs
@@ -396,10 +396,16 @@ namespace ApiDoctor.Validation
             foreach (var resource in this.Resources)
             {
                 var resourceIssues = issues.For(resource.Name);
-                if (!string.IsNullOrEmpty(resource.BaseType) && !definedTypes.Contains(resource.BaseType))
+                if (!string.IsNullOrWhiteSpace(resource.BaseType) && !definedTypes.Contains(resource.BaseType))
                 {
                     resourceIssues.Error(ValidationErrorCode.ResourceTypeNotFound,
                         $"Referenced base type {resource.BaseType} in resource {resource.Name} is not defined in the doc set!");
+                }
+
+                if (resource.BaseType != null && resource.BaseType.Trim().Length == 0)
+                {
+                    resourceIssues.Error(ValidationErrorCode.EmptyResourceBaseType,
+                        $"Missing value for referenced base type in resource {resource.Name}");
                 }
 
                 foreach (var param in resource.Parameters)

--- a/ApiDoctor.Validation/Error/validationerror.cs
+++ b/ApiDoctor.Validation/Error/validationerror.cs
@@ -104,6 +104,7 @@ namespace ApiDoctor.Validation.Error
         ExpectationConditionFailed,
         NoDocumentsFound,
         MissingResourceName,
+        EmptyResourceBaseType,
         UnsupportedLanguage,
         AllScenariosDisabled,
         ExceptionWhileValidatingMethod,


### PR DESCRIPTION
There have been issues with code snippet generation where baseType in resource topic is empty. 

This PR aims to ensure that a validation error is thrown when an empty baseType is encountered.