### PR TITLE
Add more information in error message when function call does not have key-value params

### DIFF
--- a/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
@@ -84,7 +84,6 @@ namespace ApiDoctor.Publishing.CSDL
 
             // Normalize function params
             var substitutions = new Dictionary<string, string>();
-            var parenIndex = path.IndexOf('(');
             for (int i = 0; i < path.Length; i++)
             {
                 if (path[i] == '(')
@@ -94,7 +93,7 @@ namespace ApiDoctor.Publishing.CSDL
                     if (close > -1)
                     {
                         var inner = path.Substring(i + 1, close - i - 1);
-                        substitutions[inner] = NormalizeFunctionParameters(inner, issues);
+                        substitutions[inner] = NormalizeFunctionParameters(inner, issues.For(method.Identifier));
                         i = close;
                     }
                 }
@@ -126,7 +125,8 @@ namespace ApiDoctor.Publishing.CSDL
                 var kvp = param.Split('=');
                 if (kvp.Length != 2)
                 {
-                    issues.Error(ValidationErrorCode.ParameterParserError, $"Malformed function params {funcParams}");
+                    issues.Error(ValidationErrorCode.ParameterParserError, $"Malformed function params {funcParams}. " +
+                        $"Expected key-value params e.g. /function1(key=value). Remove parentheses if no params are expected.");
                     return funcParams;
                 }
 


### PR DESCRIPTION
**Problem**
If we had a request definition like this, `https://graph.microsoft.com/beta/identityGovernance/accessReviews/historyDefinitions/b2cb022f-b7e1-40f3-9854-c65a40861c38/generateDownloadUri()`, API doctor will throw the below error which isn't very helpful.

```Error:  Malformed function params```

**Fix**
Add method name to error message to help users locate the error.
Add information to the user on how to fix the problem

```
Error: accessreviewhistorydefinition_generatedownloaduri:
      Malformed function params '. Expected key-value params e.g. function1(key=value). Remove paranthesis if no params are expected.
```