### PR TITLE
Ensure JSON request or response body is not whitespace

### DIFF
--- a/ApiDoctor.Validation/Json/JsonSchema.cs
+++ b/ApiDoctor.Validation/Json/JsonSchema.cs
@@ -119,12 +119,15 @@ namespace ApiDoctor.Validation.Json
             JContainer obj;
             try
             {
+                if (string.IsNullOrWhiteSpace(jsonInput.JsonData))
+                    throw new Exception("Expected json string was empty or whitespace only.");
+
                 var settings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None, NullValueHandling = NullValueHandling.Include, DefaultValueHandling = DefaultValueHandling.Include };
                 obj = (JContainer)JsonConvert.DeserializeObject(jsonInput.JsonData, settings);
             }
             catch (Exception ex)
             {
-                issues.Error(ValidationErrorCode.JsonParserException, $"Failed to parse json string: {jsonInput.JsonData}.", ex);
+                issues.Error(ValidationErrorCode.JsonParserException, $"Failed to parse json string: {jsonInput.JsonData.Trim()}", ex);
                 return false;
             }
 


### PR DESCRIPTION
**Bug**
API Doctor crashes if request/response body is whitespace

**Fix**
Report an error if an attempt to validate a json string that is empty or white space

Not expected to break any docs validation.

