### PR TITLE
removes reference to deprecated and vulnerable Microsoft.AspNetCore.WebUtilities

### DIFF
--- a/ApiDoctor.Validation/ApiDoctor.Validation.csproj
+++ b/ApiDoctor.Validation/ApiDoctor.Validation.csproj
@@ -23,7 +23,6 @@
     <ProjectReference Include="..\OSS\markdowndeep\MarkdownDeep\MarkdownDeep.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.CodeDom" Version="6.0.0" />

--- a/ApiDoctor.Validation/Http/HttpParser.cs
+++ b/ApiDoctor.Validation/Http/HttpParser.cs
@@ -33,9 +33,9 @@ namespace ApiDoctor.Validation.Http
     using System.IO;
     using System.Text;
     using ApiDoctor.Validation.Error;
-    using Microsoft.AspNetCore.WebUtilities;
+	using System.Web;
 
-    public class HttpParser
+	public class HttpParser
     {
         /// <summary>
         ///     Converts a raw HTTP request into an HttpWebRequest instance.
@@ -252,11 +252,7 @@ namespace ApiDoctor.Validation.Http
         {
             if (input != null && input[0] != '?') input = "?" + input;
 
-            var values = QueryHelpers.ParseQuery(input);
-            var output = new NameValueCollection();
-            foreach (var value in values)
-                output.Add(value.Key, value.Value);
-            return output;
+            return HttpUtility.ParseQueryString(input);
         }
 
         private enum ParserMode

--- a/ApiDoctor.Validation/ObjectGraph/objectgraphmerger.cs
+++ b/ApiDoctor.Validation/ObjectGraph/objectgraphmerger.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.AspNetCore.WebUtilities;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace ApiDoctor.Validation.Utility
 {
@@ -359,10 +359,10 @@ namespace ApiDoctor.Validation.Utility
         private static Dictionary<object, object> ParseEquivalentValues(string equivalentValues)
         {
             var output = new Dictionary<object, object>();
-            if (equivalentValues != null)
+            if (!string.IsNullOrEmpty(equivalentValues))
             {
-                var values = QueryHelpers.ParseQuery(equivalentValues);
-                foreach (var key in values.Keys)
+                var values = HttpUtility.ParseQueryString(equivalentValues);
+                foreach (var key in values.AllKeys)
                 {
                     output[key] = values[key];
                 }


### PR DESCRIPTION
[Microsoft.AspNetCore.WebUtilities](https://www.nuget.org/packages/Microsoft.AspNetCore.WebUtilities) has been [deprecated since 2018](https://github.com/aspnet/HttpAbstractions) and it depends on a version of [System.Text.Encodings.Web](https://www.nuget.org/packages/System.Text.Encodings.Web/4.5.0) that's vunlerable to CVE-2021-26701.

Since we were only using that library to parse query string parameters, I've replaced it by the [System.Web.HttpUtility.ParseQueryString method](https://docs.microsoft.com/en-us/dotnet/api/system.web.httputility.parsequerystring?view=netframework-4.5) instead.
