### PR TITLE
Add feature to inject documentation annotations as *Restrictions into Metadata

### DIFF
--- a/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
@@ -190,5 +190,34 @@ namespace ApiDoctor.Publishing.CSDL
 
 
         }
+
+        private static ISet GetISet(this EntityFramework edmx, 
+            string name, 
+            Func<EntityContainer, IEnumerable<ISet>> funcSelector)
+        {
+            var currentEntitySet = edmx.DataServices.Schemas.SelectMany(c => c.EntityContainers)
+                .SelectMany(funcSelector)
+                .FirstOrDefault(c => c.Name == name);
+            return currentEntitySet;
+        }
+        internal static void AddSetSourceMethods(this EntityFramework edmx,
+            MethodCollection methodCollection,
+            Func<EntityContainer, IEnumerable<ISet>> selector,
+            string name)
+        {
+            var currentSet = edmx.GetISet(name, selector);
+            if (currentSet != null)
+
+                if (currentSet.SourceMethods != null)
+                {
+                    var sourceMethods = (MethodCollection)currentSet.SourceMethods;
+                    var differences = methodCollection.Except(sourceMethods).ToList();
+                    sourceMethods.AddRange(differences);
+                }
+                else
+                {
+                    currentSet.SourceMethods = methodCollection;
+                }
+        }
     }
 }

--- a/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
@@ -208,9 +208,8 @@ namespace ApiDoctor.Publishing.CSDL
             var currentSet = edmx.GetISet(name, selector);
             if (currentSet != null)
 
-                if (currentSet.SourceMethods != null)
+                if (currentSet.SourceMethods is MethodCollection sourceMethods)
                 {
-                    var sourceMethods = (MethodCollection)currentSet.SourceMethods;
                     var differences = methodCollection.Except(sourceMethods).ToList();
                     sourceMethods.AddRange(differences);
                 }

--- a/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
@@ -40,7 +40,7 @@ namespace ApiDoctor.Publishing.CSDL
 
     internal static class CsdlExtensionMethods
     {
-        private static readonly Regex GuidRegex = new(@"[0-9a-fA-F\-]{32,36}", RegexOptions.Compiled);
+        private static readonly Regex GuidRegex = new(@"[0-9a-f\-]{32,36}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         public static string RequestUriPathOnly(this MethodDefinition method, string[] baseUrlsToRemove, IssueLogger issues)
         {
             if (string.IsNullOrWhiteSpace(method.Request)) return string.Empty;

--- a/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlextensionmethods.cs
@@ -30,6 +30,7 @@ namespace ApiDoctor.Publishing.CSDL
     using System.Collections.Generic;
     using System.Reflection;
     using System.Text;
+    using System.Text.RegularExpressions;
     using Validation.Http;
     using Validation.OData;
     using Validation.OData.Transformation;
@@ -39,7 +40,7 @@ namespace ApiDoctor.Publishing.CSDL
 
     internal static class CsdlExtensionMethods
     {
-
+        private static readonly Regex GuidRegex = new(@"[0-9a-fA-F\-]{32,36}", RegexOptions.Compiled);
         public static string RequestUriPathOnly(this MethodDefinition method, string[] baseUrlsToRemove, IssueLogger issues)
         {
             if (string.IsNullOrWhiteSpace(method.Request)) return string.Empty;
@@ -72,6 +73,7 @@ namespace ApiDoctor.Publishing.CSDL
             }
 
             // Normalize variables in the request path
+            path = GuidRegex.Replace(path, "{var}");
             path = path.ReplaceTextBetweenCharacters('{', '}', "var");
 
             if (method.RequestMetadata.SampleKeys != null)
@@ -188,9 +190,5 @@ namespace ApiDoctor.Publishing.CSDL
 
 
         }
-
-
-
-
     }
 }

--- a/ApiDoctor.Publishing/CSDL/csdlwriter.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlwriter.cs
@@ -25,18 +25,19 @@
 
 namespace ApiDoctor.Publishing.CSDL
 {
-    using Validation;
-    using Validation.Writers;
+    using ApiDoctor.Validation;
+    using ApiDoctor.Validation.Writers;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
-    using Validation.OData;
+    using ApiDoctor.Validation.OData;
+    using Validation.Config;
     using Validation.OData.Transformation;
-    using Validation.Http;
+    using ApiDoctor.Validation.Http;
     using System.IO;
-    using Validation.Error;
+    using ApiDoctor.Validation.Error;
 
     public class CsdlWriter : DocumentPublisher
     {
@@ -67,9 +68,7 @@ namespace ApiDoctor.Publishing.CSDL
             // Step 1a: Apply an transformations that may be defined in the documentation
             if (!string.IsNullOrEmpty(options.TransformOutput))
             {
-                PublishSchemaChangesConfigFile transformations = DocSet
-                    .TryLoadConfigurationFiles<PublishSchemaChangesConfigFile>(options.DocumentationSetPath)
-                    .Where(x => x.SchemaChanges.TransformationName == options.TransformOutput).FirstOrDefault();
+                PublishSchemaChangesConfigFile transformations = DocSet.TryLoadConfigurationFiles<PublishSchemaChangesConfigFile>(options.DocumentationSetPath).Where(x => x.SchemaChanges.TransformationName == options.TransformOutput).FirstOrDefault();
                 if (null == transformations)
                 {
                     throw new KeyNotFoundException($"Unable to locate a transformation set named {options.TransformOutput}. Aborting.");
@@ -112,7 +111,7 @@ namespace ApiDoctor.Publishing.CSDL
                 var outputFullName = GenerateOutputFileFullName(options.SourceMetadataPath, outputFolder, outputFilenameSuffix);
                 Console.WriteLine($"Publishing metadata to {outputFullName}");
 
-                using (var writer = File.CreateText(outputFullName))
+                using (var writer = System.IO.File.CreateText(outputFullName))
                 {
                     await writer.WriteAsync(xmlData);
                     await writer.FlushAsync();
@@ -127,7 +126,7 @@ namespace ApiDoctor.Publishing.CSDL
 
         private string GenerateOutputFileFullName(string templateFilename, string outputFolderPath, string filenameSuffix)
         {
-            var outputDir = new DirectoryInfo(outputFolderPath);
+            var outputDir = new System.IO.DirectoryInfo(outputFolderPath);
             outputDir.Create();
 
             filenameSuffix = filenameSuffix ?? "";
@@ -135,19 +134,18 @@ namespace ApiDoctor.Publishing.CSDL
             string filename = null;
             if (!string.IsNullOrEmpty(templateFilename))
             {
-                filename = $"{Path.GetFileNameWithoutExtension(templateFilename)}{filenameSuffix}{Path.GetExtension(templateFilename)}";
+                filename = $"{System.IO.Path.GetFileNameWithoutExtension(templateFilename)}{filenameSuffix}{System.IO.Path.GetExtension(templateFilename)}";
             }
             else
             {
                 filename = $"metadata{filenameSuffix}.xml";
             }
 
-            var outputFullName = Path.Combine(outputDir.FullName, filename);
+            var outputFullName = System.IO.Path.Combine(outputDir.FullName, filename);
             return outputFullName;
         }
 
-        public EntityFramework CreateEntityFrameworkFromDocs(IssueLogger issues, string sourcePath = null,
-            bool? generateFromDocs = null)
+        public EntityFramework CreateEntityFrameworkFromDocs(IssueLogger issues, string sourcePath = null, bool? generateFromDocs = null)
         {
             sourcePath = sourcePath ?? options.SourceMetadataPath;
 
@@ -156,12 +154,12 @@ namespace ApiDoctor.Publishing.CSDL
             {
                 try
                 {
-                    if (!File.Exists(sourcePath))
+                    if (!System.IO.File.Exists(sourcePath))
                     {
-                        throw new FileNotFoundException($"Unable to locate source file: {sourcePath}");
+                        throw new System.IO.FileNotFoundException($"Unable to locate source file: {sourcePath}");
                     }
 
-                    using (FileStream stream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read))
+                    using (System.IO.FileStream stream = new System.IO.FileStream(sourcePath, System.IO.FileMode.Open, System.IO.FileAccess.Read))
                     {
                         if (options.Formats.HasFlag(MetadataFormat.EdmxInput))
                         {
@@ -175,11 +173,9 @@ namespace ApiDoctor.Publishing.CSDL
                         }
                         else
                         {
-                            throw new InvalidOperationException(
-                                "Source file was specified but no format for source file was provided.");
+                            throw new InvalidOperationException("Source file was specified but no format for source file was provided.");
                         }
                     }
-
                     if (options.Namespaces != null && options.Namespaces.Any())
                     {
                         var schemas = edmx.DataServices.Schemas.ToArray();
@@ -199,20 +195,17 @@ namespace ApiDoctor.Publishing.CSDL
                 }
             }
 
-            bool generateNewElements = (generateFromDocs == null && !options.SkipMetadataGeneration) ||
-                                       (generateFromDocs.HasValue && generateFromDocs.Value);
+            bool generateNewElements = (generateFromDocs == null && !options.SkipMetadataGeneration) || (generateFromDocs.HasValue && generateFromDocs.Value);
 
             // Add resources 
             if (Documents.Files.Any())
             {
                 foreach (var resource in this.Documents.Resources)
                 {
-                    var targetSchema = FindOrCreateSchemaForNamespace(resource.Name.NamespaceOnly(), edmx,
-                        generateNewElements: generateNewElements);
+                    var targetSchema = FindOrCreateSchemaForNamespace(resource.Name.NamespaceOnly(), edmx, generateNewElements: generateNewElements);
                     if (targetSchema != null)
                     {
-                        AddResourceToSchema(targetSchema, resource, edmx, issues,
-                            generateNewElements: generateNewElements);
+                        AddResourceToSchema(targetSchema, resource, edmx, issues, generateNewElements: generateNewElements);
                     }
                 }
 
@@ -286,11 +279,8 @@ namespace ApiDoctor.Publishing.CSDL
                             }
                         }
 
-                        Dictionary<string, ODataCapabilities> capabilitiesPerProperty =
-                            new Dictionary<string, ODataCapabilities>();
-                        foreach (var annotation in complex.Contributors
-                                     .Where(c => c.OriginalMetadata?.OdataAnnotations != null)
-                                     .SelectMany(c => c.OriginalMetadata.OdataAnnotations))
+                        Dictionary<string, ODataCapabilities> capabilitiesPerProperty = new Dictionary<string, ODataCapabilities>();
+                        foreach (var annotation in complex.Contributors.Where(c => c.OriginalMetadata?.OdataAnnotations != null).SelectMany(c => c.OriginalMetadata.OdataAnnotations))
                         {
                             if (annotation?.Capabilities != null)
                             {
@@ -301,8 +291,7 @@ namespace ApiDoctor.Publishing.CSDL
                                     continue;
                                 }
 
-                                annotation.Capabilities.MergeWith(capabilities,
-                                    issues.For(complex.Name + "/annotations"));
+                                annotation.Capabilities.MergeWith(capabilities, issues.For(complex.Name + "/annotations"));
                             }
                         }
 
@@ -338,13 +327,13 @@ namespace ApiDoctor.Publishing.CSDL
                                     annotation.Records.Add(new Record
                                     {
                                         PropertyValues = new List<PropertyValue>
-                                        {
-                                            new PropertyValue
                                             {
-                                                Property = "Referenceable",
-                                                Bool = capabilities.Referenceable.GetValueOrDefault(),
-                                            },
-                                        }
+                                                new PropertyValue
+                                                {
+                                                    Property ="Referenceable",
+                                                    Bool = capabilities.Referenceable.GetValueOrDefault(),
+                                                },
+                                            }
                                     });
                                 }
 
@@ -353,16 +342,15 @@ namespace ApiDoctor.Publishing.CSDL
                                     annotation.Records.Add(new Record
                                     {
                                         PropertyValues = new List<PropertyValue>
-                                        {
-                                            new PropertyValue
                                             {
-                                                Property = "Navigability",
-                                                EnumMember = string.IsNullOrEmpty(capabilities.Navigability)
-                                                    ? string.Empty
-                                                    : ("Org.OData.Capabilities.V1.NavigationType/" +
-                                                       capabilities.Navigability)
-                                            },
-                                        }
+                                                new PropertyValue
+                                                {
+                                                    Property ="Navigability",
+                                                    EnumMember = string.IsNullOrEmpty(capabilities.Navigability)
+                                                        ? string.Empty
+                                                        : ("Org.OData.Capabilities.V1.NavigationType/" + capabilities.Navigability)
+                                                },
+                                            }
                                     });
                                 }
 
@@ -407,15 +395,14 @@ namespace ApiDoctor.Publishing.CSDL
                         foreach (var operation in schema.Actions.Cast<ActionOrFunctionBase>().Concat(schema.Functions))
                         {
                             var target =
-                                (operation.Parameters.FirstOrDefault(p => p.Name.IEquals("bindingParameter")).Type ??
-                                 schema.Namespace) +
+                                (operation.Parameters.FirstOrDefault(p => p.Name.IEquals("bindingParameter")).Type ?? schema.Namespace) +
                                 "/" +
                                 operation.Name;
 
-                            AddHttpRequestsAnnotations(annotationsMap, operation.SourceMethods as MethodCollection,
-                                target, issues.For(target));
+                            AddHttpRequestsAnnotations(annotationsMap, operation.SourceMethods as MethodCollection, target, issues.For(target));
                         }
                     }
+
                     schema.Annotations = annotationsMap.Values.ToList();
 
                     if (this.options.Annotations.HasFlag(AnnotationOptions.OnlyAnnotations))
@@ -474,7 +461,7 @@ namespace ApiDoctor.Publishing.CSDL
                         {
                             PropertyValues = new List<PropertyValue>
                             {
-                                new PropertyValue {Property = property, Bool = value.GetValueOrDefault()},
+                                new PropertyValue { Property=property, Bool = value.GetValueOrDefault()},
                             }
                         }
                     };
@@ -498,6 +485,1138 @@ namespace ApiDoctor.Publishing.CSDL
             }
         }
 
+        private static void AddHttpRequestsAnnotations(IODataAnnotatable annotatable, MethodCollection methods, IssueLogger issues)
+        {
+            if (methods != null)
+            {
+                var annotation = new Annotation
+                {
+                    Term = "Org.OData.Core.V1.HttpRequests",
+                    Collection = new RecordCollection
+                    {
+                        Records = new List<Record>(),
+                    }
+                };
+
+                foreach (var method in methods)
+                {
+                    try
+                    {
+                        var record = GenerateHttpRequestMethodAnnotation(method, issues);
+                        annotation.Collection.Records.Add(record);
+                    }
+                    catch (Exception ex)
+                    {
+                        issues.Error(ValidationErrorCode.Unknown,
+                            $"Exception in {method.SourceFile.DisplayName}!", ex);
+                    }
+                }
+
+                if (annotatable.Annotation == null)
+                {
+                    annotatable.Annotation = new List<Annotation>();
+                }
+
+                annotatable.Annotation.Add(annotation);
+            }
+        }
+
+        private static Record GenerateHttpRequestMethodAnnotation(MethodDefinition method, IssueLogger issues)
+        {
+            HttpRequest request;
+            HttpParser.TryParseHttpRequest(method.Request, out request, issues);
+            HttpResponse response;
+            HttpParser.TryParseHttpResponse(method.ExpectedResponse, out response, issues);
+            var record = new Record
+            {
+                PropertyValues = new List<PropertyValue>
+                {
+                    new PropertyValue
+                    {
+                        Property = "Description",
+                        String = method.Description.ToStringClean(),
+                    },
+                    new PropertyValue { Property = "MethodDescription", String = method.Title },
+                    new PropertyValue { Property = "MethodType", String = method.HttpMethodVerb()},
+                    new PropertyValue
+                    {
+                        Property = "CustomHeaders",
+                        Collection = new RecordCollection
+                        {
+                            Records = (method.Parameters?.Where(p=>p.Location == ParameterLocation.Header)?.Select(p =>
+                                new Record
+                                {
+                                    PropertyValues = new List<PropertyValue>
+                                    {
+                                        new PropertyValue { Property = "Name", String = p.Name },
+                                        new PropertyValue { Property = "Description", String = p.Description.ToStringClean() },
+                                        new PropertyValue { Property = "Required", Bool = p.Required.GetValueOrDefault() },
+                                    }
+                                }))?.ToList()
+                        },
+                    },
+                    new PropertyValue
+                    {
+                        Property = "CustomQueryOptions",
+                        Collection = new RecordCollection
+                        {
+                            Records = (method.Parameters?.Where(p=>p.Location == ParameterLocation.QueryString)?.Select(p =>
+                                new Record
+                                {
+                                    PropertyValues = new List<PropertyValue>
+                                    {
+                                        new PropertyValue { Property = "Name", String = p.Name },
+                                        new PropertyValue { Property = "Description", String = p.Type.ToStringClean() },
+                                        new PropertyValue { Property = "Required", Bool = p.Required.GetValueOrDefault() },
+                                    }
+                                }))?.ToList()
+                        },
+                    },
+                    new PropertyValue
+                    {
+                        Property = "HttpResponses",
+                        Collection = new RecordCollection
+                        {
+                            Records = new List<Record>
+                            {
+                                new Record
+                                {
+                                    PropertyValues = new List<PropertyValue>
+                                    {
+                                        new PropertyValue { Property = "ResponseCode", String  = response?.StatusCode.ToString() },
+                                        new PropertyValue
+                                        {
+                                            Property = "Examples" ,
+                                            Collection = new RecordCollection
+                                            {
+                                                Records = new List<Record>
+                                                {
+                                                    new Record
+                                                    {
+                                                        Type = "Org.OData.Core.V1.InlineExample",
+                                                        PropertyValues = new List<PropertyValue>
+                                                        {
+                                                            new PropertyValue { Property = "InlineValue", String  = response?.Body, },
+                                                            new PropertyValue { Property = "Description", String = response?.ContentType },
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new PropertyValue
+                    {
+                        Property = "SecuritySchemes",
+                        Collection = new RecordCollection
+                        {
+                            Records = (method?.SourceFile?.AuthScopes?.Where(scp=>scp?.Scope != null && !scp.Scope.IContains("not supported")).Select(scp =>
+                                new Record
+                                {
+                                    PropertyValues = new List<PropertyValue>
+                                    {
+                                        new PropertyValue { Property = "AuthorizationSchemeName", String = scp.Title },
+                                        new PropertyValue
+                                        {
+                                            Property = "RequiredScopes",
+                                            Collection = new RecordCollection { Strings = scp.Scope?.Split(new[] {',',';',' ' }, StringSplitOptions.RemoveEmptyEntries).ToList() }
+                                        }
+                                    }
+                                }))?.ToList()
+                        },
+                    },
+                },
+            };
+
+            return record;
+        }
+
+        private static void MergeAnnotations(string fullName, IODataAnnotatable annotatable, Dictionary<string, Annotations> schemaLevelAnnotations)
+        {
+            if (annotatable.Annotation?.Count > 0)
+            {
+                Annotations annotations;
+                if (schemaLevelAnnotations.TryGetValue(fullName, out annotations))
+                {
+                    foreach (var annotation in annotatable.Annotation)
+                    {
+                        var existingAnnotation = annotations.AnnotationList.FirstOrDefault(a => a.Term == annotation.Term);
+                        if (existingAnnotation != null && annotation.Collection != null && annotation.Collection.Records?.Count > 0)
+                        {
+                            if (existingAnnotation.Collection == null)
+                            {
+                                existingAnnotation.Collection = new RecordCollection();
+                            }
+
+                            if (existingAnnotation.Collection.Records == null)
+                            {
+                                existingAnnotation.Collection.Records = new List<Record>();
+                            }
+
+                            existingAnnotation.Collection.Records.AddRange(annotation.Collection.Records);
+                        }
+                        else
+                        {
+                            annotations.AnnotationList.Add(annotation);
+                        }
+                    }
+                }
+                else
+                {
+                    schemaLevelAnnotations[fullName] = new Annotations
+                    {
+                        Target = fullName,
+                        AnnotationList = annotatable.Annotation,
+                    };
+                }
+
+                annotatable.Annotation = null;
+            }
+        }
+
+        /// <summary>
+        /// Scan the MethodDefintions in the documentation and create actions and functions in the
+        /// EntityFramework for matching call patterns.
+        /// </summary>
+        /// <param name="edmx"></param>
+        private void ProcessRestRequestPaths(EntityFramework edmx, string[] baseUrlsToRemove, IssueLogger issues)
+        {
+            Dictionary<string, MethodCollection> uniqueRequestPaths = GetUniqueRequestPaths(baseUrlsToRemove, issues);
+            List<string> pathsToProcess = uniqueRequestPaths.Keys.OrderBy(p => p.Count(c => c == '/')).ThenBy(p => p).ToList();
+
+            for (int attempts = 1; attempts < 10 && pathsToProcess.Count > 0; attempts++)
+            {
+                Dictionary<string, Exception> pathsToRetry = new Dictionary<string, Exception>();
+                foreach (var path in pathsToProcess)
+                {
+                    var methodCollection = uniqueRequestPaths[path];
+
+                    ODataTargetInfo requestTarget = null;
+                    try
+                    {
+                        // TODO: If we have an input Edmx, we may already know what this so we don't need to infer anything.
+                        // if that is the case, we should just update it with anything else we know from the documentation.
+                        requestTarget = ParseRequestTargetType(path, methodCollection, edmx, issues);
+                        if (requestTarget.Classification == ODataTargetClassification.Unknown &&
+                            !string.IsNullOrEmpty(requestTarget.Name) &&
+                            requestTarget.QualifiedType != null)
+                        {
+                            CreateNewActionOrFunction(edmx, methodCollection, requestTarget.Name, requestTarget.QualifiedType, issues.For(requestTarget.Name));
+                        }
+                        else if (requestTarget.Classification == ODataTargetClassification.EntityType)
+                        {
+                            // We've learned more about this entity type, let's add that information to the state
+                            AppendToEntityType(edmx, requestTarget, methodCollection);
+                        }
+                        else if (requestTarget.Classification == ODataTargetClassification.NavigationProperty)
+                        {
+                            // TODO: Record somewhere the operations that are available on this NavigationProperty
+                            AppendToNavigationProperty(edmx, requestTarget, methodCollection, issues);
+                        }
+                        else
+                        {
+                            // TODO: Are there interesting things to learn here?
+                            //Console.WriteLine("Found type {0}: {1}", requestTarget.Classification, path);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        pathsToRetry.Add(path, ex);
+                        continue;
+                    }
+                }
+
+                if (pathsToRetry.Count < pathsToProcess.Count)
+                {
+                    pathsToProcess = pathsToRetry.Keys.ToList();
+                }
+                else
+                {
+                    issues.Message($"Failed to resolve the following paths after {attempts} attempts:");
+                    foreach (var kvp in pathsToRetry)
+                    {
+                        issues.Warning(ValidationErrorCode.Unknown, $"Couldn't serialize request for path {kvp.Key} into EDMX", kvp.Value);
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        private void AppendToNavigationProperty(EntityFramework edmx, ODataTargetInfo navigationProperty, MethodCollection methods, IssueLogger issues)
+        {
+            EntityType parentType = edmx.ResourceWithIdentifier<EntityType>(navigationProperty.QualifiedType);
+
+            var matchingProperty =
+                parentType.NavigationProperties.FirstOrDefault(np => np.Name == navigationProperty.Name) ??
+                parentType.Properties.FirstOrDefault(p => p.Name == navigationProperty.Name);
+            if (null != matchingProperty)
+            {
+                // TODO: Append information from methods into this navigation property
+                StringBuilder sb = new StringBuilder();
+                const string seperator = ", ";
+                sb.AppendWithCondition(methods.GetAllowed, "GET", seperator);
+                sb.AppendWithCondition(methods.PostAllowed, "POST", seperator);
+                sb.AppendWithCondition(methods.PutAllowed, "PUT", seperator);
+                sb.AppendWithCondition(methods.DeleteAllowed, "DELETE", seperator);
+                issues.Message($"Collection '{navigationProperty.QualifiedType + "/" + navigationProperty.Name}' supports: ({sb})");
+            }
+            else
+            {
+                issues.Error(ValidationErrorCode.RequiredPropertiesMissing,
+                    $"EntityType '{navigationProperty.QualifiedType}' doesn't have a matching Property '{navigationProperty.Name}' but a request exists for this. Sounds like a documentation error.");
+            }
+        }
+
+        /// <summary>
+        /// Use the properties of methodCollection to augment what we know about this entity type
+        /// </summary>
+        /// <param name="requestTarget"></param>
+        /// <param name="methodCollection"></param>
+        private void AppendToEntityType(EntityFramework edmx, ODataTargetInfo requestTarget, MethodCollection methodCollection)
+        {
+            StringBuilder sb = new StringBuilder();
+            const string seperator = ", ";
+            sb.AppendWithCondition(methodCollection.GetAllowed, "GET", seperator);
+            sb.AppendWithCondition(methodCollection.PostAllowed, "POST", seperator);
+            sb.AppendWithCondition(methodCollection.PutAllowed, "PUT", seperator);
+            sb.AppendWithCondition(methodCollection.DeleteAllowed, "DELETE", seperator);
+        }
+
+        private void CreateNewActionOrFunction(
+            EntityFramework edmx,
+            MethodCollection methodCollection,
+            string name,
+            string boundToType,
+            IssueLogger issues,
+            bool recursing = false)
+        {
+            if (name.IEquals("$ref") ||
+                name.IEquals("$value"))
+            {
+                issues.Message("Ignoring $ref and $value. No schema changes needed.");
+                return;
+            }
+
+            if (name.StartsWith("{"))
+            {
+                var currentType = edmx.DataServices.Schemas.FindTypeWithIdentifier(boundToType) as ComplexType;
+                if (currentType?.OpenType == true)
+                {
+                    issues.Message($"Ignoring {name} navigation into open type. No schema changes needed.");
+                }
+                else
+                {
+                    issues.Warning(ValidationErrorCode.Unknown, $"Don't know what to do with {name}; it's not a function");
+                }
+
+                return;
+            }
+
+            // Create a new action (not idempotent) / function (idempotent) based on this request method!
+            ActionOrFunctionBase target = null;
+            if (methodCollection.AllMethodsIdempotent)
+            {
+                target = new Validation.OData.Function
+                {
+                    IsComposable = methodCollection.Any(mc => mc.RequestMetadata.IsComposable),
+                };
+            }
+            else
+            {
+                target = new Validation.OData.Action();
+            }
+
+            if (this.options.ShowSources)
+            {
+                target.SourceFiles = string.Join(";", new HashSet<string>(methodCollection.Select(m => m.SourceFile).Select(f => Path.GetFileName(f.FullPath)).ToList()));
+            }
+
+            if (this.options.Annotations.HasFlag(AnnotationOptions.HttpRequests))
+            {
+                AddHttpRequestsAnnotations(target, methodCollection, issues.For(name));
+            }
+
+            target.SourceMethods = methodCollection;
+
+            target.Name = name.TypeOnly();
+            target.IsBound = true;
+            target.Parameters.Add(new Parameter { Name = "bindingParameter", Type = boundToType, IsNullable = false });
+            foreach (var param in methodCollection.Where(m => m.HttpMethodVerb() == "POST").SelectMany(m => m.RequestBodyParameters))
+            {
+                try
+                {
+                    var existingParam = target.Parameters.FirstOrDefault(p => p.Name.IEquals(param.Name));
+                    if (existingParam != null)
+                    {
+                        existingParam.Type = ParameterDataType.ChooseBest(existingParam.Type, param.Type.ODataResourceName());
+                    }
+                    else
+                    {
+                        target.Parameters.Add(
+                            new Parameter
+                            {
+                                Name = param.Name,
+                                Type = param.Type.ODataResourceName(),
+                                IsNullable = (param.Required.HasValue ? param.Required.Value : false)
+                            });
+                    }
+                }
+                catch (Exception ex)
+                {
+                    issues.Error(ValidationErrorCode.Unknown, $"Exception when adding parameter {param.Name} with type {param.Type}", ex);
+                    throw;
+                }
+            }
+
+            if (target.Name.Contains("("))
+            {
+                target.ParameterizedName = target.Name;
+                var pathParameters = target.Name.TextBetweenCharacters('(', ')').Split(',');
+                target.Name = target.Name.Substring(0, target.Name.IndexOf('('));
+                foreach (var param in pathParameters.Where(p => !string.IsNullOrEmpty(p)))
+                {
+                    var paramName = param.Split('=')[0];
+                    var matchingParamDef = methodCollection.SelectMany(m => m.Parameters).FirstOrDefault(p => p.Name == paramName);
+                    if (matchingParamDef == null)
+                    {
+                        issues.Error(ValidationErrorCode.Unknown,
+                            $"Couldn't find definition for parameter {param} in {name} after looking in {string.Join(",", methodCollection.Select(m => m.SourceFile?.DisplayName))}");
+                    }
+                    else
+                    {
+                        target.Parameters.Add(
+                            new Parameter
+                            {
+                                Name = matchingParamDef.Name,
+                                Type = matchingParamDef.Type.ODataResourceName(),
+                                IsNullable = (matchingParamDef.Required.GetValueOrDefault())
+                            });
+
+                        // if we have an optional param, recursively call again without it
+                        if (matchingParamDef.Optional.GetValueOrDefault() == true)
+                        {
+                            var overloadName = target.ParameterizedName.Replace($"{paramName}={{var}}", string.Empty);
+                            CreateNewActionOrFunction(edmx, methodCollection, overloadName, boundToType, issues);
+                        }
+                    }
+                }
+
+                if (!recursing)
+                {
+                    // note: this is very rough and brittle. only intended for limited use right now.
+                    // if there are other sample calling patterns for this function, create bindings for them too.
+                    foreach (var sample in methodCollection.SelectMany(mc => mc.SourceFile.Samples).SelectMany(s => s.Samples))
+                    {
+                        if (sample.EndsWith(")") && sample.Contains("("))
+                        {
+                            var overloadName = target.ParameterizedName.ReplaceTextBetweenCharacters('(', ')', sample.TextBetweenCharacters('(', ')'));
+                            CreateNewActionOrFunction(edmx, methodCollection, overloadName, boundToType, issues, recursing: true);
+                        }
+                        else if (sample.EndsWith(target.Name))
+                        {
+                            // overload with no parameters
+                            var overloadName = target.Name;
+                            CreateNewActionOrFunction(edmx, methodCollection, overloadName, boundToType, issues, recursing: true);
+                        }
+                    }
+                }
+            }
+
+            if (methodCollection.ResponseType != null)
+            {
+                target.ReturnType = new ReturnType { Type = methodCollection.ResponseType.ODataResourceName(), Nullable = false };
+                var targetAction = target as Validation.OData.Action;
+                if (targetAction != null &&
+                    target.Parameters.FirstOrDefault(p => p.Name == "bindingParameter")?.Type?.StartsWith("Collection(") == false)
+                {
+                    targetAction.EntitySetPath = "bindingParameter";
+                }
+            }
+
+            var schemaName = name.HasNamespace() ? name.NamespaceOnly() : edmx.DataServices.Schemas.FirstOrDefault()?.Namespace;
+            var schema = FindOrCreateSchemaForNamespace(schemaName, edmx, true);
+
+            // first see if this action or function is already bound to a base type with the same params.
+            // if so, this definition is redundant.
+            foreach (var existingFunction in schema.Functions.Cast<ActionOrFunctionBase>().Concat(schema.Actions).ToList())
+            {
+                if (existingFunction.CanSubstituteFor(target, edmx))
+                {
+                    return;
+                }
+
+                // on the other hand, if the opposite is true...
+                if (target.CanSubstituteFor(existingFunction, edmx))
+                {
+                    if (target is Function)
+                    {
+                        schema.Functions.Remove((Function)existingFunction);
+                    }
+                    else
+                    {
+                        schema.Actions.Remove((Validation.OData.Action)existingFunction);
+                    }
+                }
+            }
+
+            if (target is Function)
+            {
+                schema.Functions.Add((Function)target);
+            }
+            else
+            {
+                schema.Actions.Add((Validation.OData.Action)target);
+            }
+        }
+
+        /// <summary>
+        /// Walks the requestPath through the resources / entities defined in the edmx and resolves
+        /// the type of request represented by the path
+        /// </summary>
+        /// <param name="requestPath"></param>
+        /// <param name="requestMethod"></param>
+        /// <param name="edmx"></param>
+        /// <returns></returns>
+        private static ODataTargetInfo ParseRequestTargetType(string requestPath, MethodCollection requestMethodCollection, EntityFramework edmx, IssueLogger issues)
+        {
+            string[] requestParts = requestPath.Substring(1).Split(new char[] { '/' });
+
+            EntityContainer entryPoint = (from s in edmx.DataServices.Schemas
+                                          where s.EntityContainers.Count > 0
+                                          select s.EntityContainers.FirstOrDefault()).SingleOrDefault();
+
+            if (entryPoint == null) throw new InvalidOperationException("Couldn't locate an EntityContainer to begin target resolution");
+
+            IODataNavigable currentObject = entryPoint;
+            IODataNavigable previousObject = null;
+
+            for (int i = 0; i < requestParts.Length; i++)
+            {
+                bool isLastSegment = i == requestParts.Length - 1;
+                string uriPart = requestParts[i];
+                IODataNavigable nextObject = null;
+                if (uriPart == "{var}" &&
+                    (currentObject as ComplexType)?.OpenType != true)
+                {
+                    try
+                    {
+                        nextObject = currentObject.NavigateByEntityTypeKey(edmx, issues.For($"ExampleRequest_{string.Join("/", requestParts.Take(i + 1))}"));
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new NotSupportedException("Unable to navigation into EntityType by key: " + currentObject.TypeIdentifier + " (" + ex.Message + ")");
+                    }
+                }
+                else
+                {
+                    nextObject = currentObject.NavigateByUriComponent(
+                        uriPart,
+                        edmx,
+                        issues.For($"ExampleRequest_{string.Join("/", requestParts.Take(i + 1))}"),
+                        isLastSegment);
+                }
+
+                if (nextObject == null && isLastSegment)
+                {
+                    // The last component wasn't known already, so that means we have a new thing.
+
+                    return new ODataTargetInfo
+                    {
+                        Name = uriPart,
+                        Classification = ODataTargetClassification.Unknown,
+                        QualifiedType = edmx.LookupIdentifierForType(currentObject)
+                    };
+                }
+                else if (nextObject == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Uri path requires navigating into unknown object hierarchy: missing property '{uriPart}' on '{currentObject.TypeIdentifier}'. Possible issues:\r\n" +
+                        $"\t 1) Doc bug where '{uriPart}' isn't defined on the resource.\r\n" +
+                        $"\t 2) Doc bug where '{uriPart}' is an example key and should instead be replaced with a placeholder like {{item-id}} or declared in the sampleKeys annotation.\r\n" +
+                        $"\t 3) Doc bug where '{currentObject.TypeIdentifier}' is supposed to be an entity type, but is being treated as a complex because it (and its ancestors) are missing the keyProperty annotation.\r\n");
+                }
+
+                previousObject = currentObject;
+                currentObject = nextObject;
+            }
+
+            var response = new ODataTargetInfo
+            {
+                Name = requestParts.Last(),
+                QualifiedType = edmx.LookupIdentifierForType(currentObject)
+            };
+
+            if (currentObject is EntityType)
+                response.Classification = ODataTargetClassification.EntityType;
+            else if (currentObject is EntityContainer)
+                response.Classification = ODataTargetClassification.EntityContainer;
+            else if (currentObject is ODataSimpleType)
+                response.Classification = ODataTargetClassification.SimpleType;
+            else if (currentObject is ODataCollection)
+            {
+                if (previousObject != entryPoint)
+                {
+                    if (response.Name.Contains("."))
+                    {
+                        response.Classification = ODataTargetClassification.TypeCast;
+                    }
+                    else
+                    {
+                        response.Classification = ODataTargetClassification.NavigationProperty;
+                    }
+
+                    response.QualifiedType = edmx.LookupIdentifierForType(previousObject);
+                }
+                else
+                {
+                    response.Classification = ODataTargetClassification.EntitySet;
+                }
+            }
+            else if (currentObject is ComplexType)
+            {
+                response.Classification = ODataTargetClassification.ComplexType;
+            }
+            else
+            {
+                throw new NotSupportedException(string.Format("Unhandled object type: {0}", currentObject.GetType().Name));
+            }
+
+            return response;
+        }
+
+        // EntitySet is something in the format of /name/{var}
+        private static readonly System.Text.RegularExpressions.Regex EntitySetPathRegEx = new (@"^\/(\w*)\/{var}$", System.Text.RegularExpressions.RegexOptions.Compiled);
+        // Singleton is something in the format of /name
+        private static readonly System.Text.RegularExpressions.Regex SingletonPathRegEx = new (@"^\/(\w*)$", System.Text.RegularExpressions.RegexOptions.Compiled);
+        private static readonly System.Text.RegularExpressions.Regex FullSingletonPathRegEx = new(@"\/(\w*)", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        /// <summary>
+        /// Parse the URI paths for methods defined in the documentation and construct an entity container that contains these
+        /// entity sets / singletons in the largest namespace.
+        /// </summary>
+        private void BuildEntityContainer(EntityFramework edmx, string[] baseUrlsToRemove, IssueLogger issues)
+        {
+            // Check to see if an entitycontainer already exists
+            foreach (var s in edmx.DataServices.Schemas)
+            {
+                if (s.EntityContainers.Any())
+                    return;
+            }
+
+            Dictionary<string, MethodCollection> uniqueRequestPaths = GetUniqueRequestPaths(baseUrlsToRemove, issues);
+            var resourcePaths = uniqueRequestPaths.Keys.OrderBy(x => x).ToArray();
+
+            EntityContainer container = new EntityContainer();
+            foreach (var path in resourcePaths)
+            {
+                try
+                {
+                    var methodCollection = uniqueRequestPaths[path];
+
+                    if (EntitySetPathRegEx.IsMatch(path))
+                    {
+                        var name = EntitySetPathRegEx.Match(path).Groups[1].Value;
+                        var entitySet = new EntitySet
+                        {
+                            Name = name,
+                            EntityType = methodCollection.ResponseType?.ODataResourceName(),
+                            SourceMethods = methodCollection,
+                        };
+
+                        if (this.options.Annotations.HasFlag(AnnotationOptions.HttpRequests))
+                        {
+                            AddHttpRequestsAnnotations(entitySet, methodCollection, issues.For(path + "/HttpRequestsAnnotations"));
+                        }
+
+                        container.EntitySets.Add(entitySet);
+                    }
+                    else if (SingletonPathRegEx.IsMatch(path))
+                    {
+                        // Before we declare this a singleton, see if any other paths that have the same root match the entity set regex
+                        var query = (from p in resourcePaths where p.StartsWith(path + "/") && EntitySetPathRegEx.IsMatch(p) select p);
+                        if (query.Any())
+                        {
+                            // If there's a similar resource path that matches the entity, we don't declare a singleton.
+                            continue;
+                        }
+
+                        var name = SingletonPathRegEx.Match(path).Groups[1].Value;
+                        var singleton = new Singleton
+                        {
+                            Name = name,
+                            Type = methodCollection.ResponseType.ODataResourceName(),
+                            SourceMethods = methodCollection,
+                        };
+
+                        if (this.options.Annotations.HasFlag(AnnotationOptions.HttpRequests))
+                        {
+                            AddHttpRequestsAnnotations(singleton, methodCollection, issues.For(path + "/HttpRequestsAnnotations"));
+                        }
+
+                        container.Singletons.Add(singleton);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    issues.Error(ValidationErrorCode.Unknown, $"BuildEntityContainer: error in path {path}", ex);
+                }
+            }
+
+            Schema defaultSchema;
+            if (DocSet.SchemaConfig.DefaultNamespace != null)
+            {
+                defaultSchema = edmx.DataServices.Schemas.Single(s => s.Namespace.IEquals(DocSet.SchemaConfig.DefaultNamespace));
+            }
+            else
+            {
+                // if the default schema isn't specified, assume the most common schema in the docs is the default
+                defaultSchema = edmx.DataServices.Schemas.OrderByDescending(s => s.EntityTypes.Count).First();
+            }
+
+            container.Name = this.options.EntityContainerName ?? defaultSchema.Namespace;
+            defaultSchema.EntityContainers.Add(container);
+        }
+
+        private Dictionary<string, MethodCollection> cachedUniqueRequestPaths { get; set; }
+
+        /// <summary>
+        /// Return a dictionary of the unique request paths in the
+        /// documentation and the method definitions that defined them.
+        /// </summary>
+        /// <returns></returns>
+        private Dictionary<string, MethodCollection> GetUniqueRequestPaths(string[] baseUrlsToRemove, IssueLogger issues)
+        {
+            if (cachedUniqueRequestPaths == null)
+            {
+                Dictionary<string, MethodCollection> uniqueRequestPaths = new Dictionary<string, MethodCollection>();
+                foreach (var m in Documents.Methods)
+                {
+                    if (m.RequestMetadata?.OpaqueUrl == true)
+                    {
+                        // ignore requests with opaque urls, as they don't contribute to the schema
+                        continue;
+                    }
+
+                    if (m.ExpectedResponseMetadata != null && m.ExpectedResponseMetadata.ExpectError)
+                    {
+                        // Ignore things that are expected to error
+                        continue;
+                    }
+
+                    var path = m.RequestUriPathOnly(baseUrlsToRemove, issues);
+                    if (!path.StartsWith("/"))
+                    {
+                        // Ignore absolute URI paths
+                        continue;
+                    }
+
+                    if (m.RequestMetadata.Tags != null &&
+                        DocSet.SchemaConfig.SupportedTags != null &&
+                        !DocSet.SchemaConfig.SupportedTags.Intersect(m.RequestMetadata.TagList).Any())
+                    {
+                        // ignore tagged request examples if the current service doesn't support that tag
+                        continue;
+                    }
+
+                    issues.Message($"Converted '{m.Request.FirstLineOnly()}' into generic form '{path}'");
+
+                    if (!uniqueRequestPaths.ContainsKey(path))
+                    {
+                        uniqueRequestPaths.Add(path, new MethodCollection());
+                    }
+                    uniqueRequestPaths[path].Add(m);
+
+                    issues.Message($"{path} :: {m.RequestMetadata.ResourceType} --> {m.ExpectedResponseMetadata?.ResourceType}");
+                }
+
+                cachedUniqueRequestPaths = uniqueRequestPaths;
+            }
+            return cachedUniqueRequestPaths;
+        }
+
+        /// <summary>
+        /// Find an existing schema definiton or create a new one in an entity framework for a given namespace.
+        /// </summary>
+        /// <param name="ns"></param>
+        /// <param name="edmx"></param>
+        /// <returns></returns>
+        private Schema FindOrCreateSchemaForNamespace(string ns, EntityFramework edmx, bool overrideNamespaceFilter = false, bool generateNewElements = true)
+        {
+            // Check to see if this is a namespace that should be exported.
+            if (!overrideNamespaceFilter && options.Namespaces != null && !options.Namespaces.Contains(ns))
+            {
+                return null;
+            }
+
+            if (ns.Equals("odata", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var matchingSchema = (from s in edmx.DataServices.Schemas
+                                  where s.Namespace == ns
+                                  select s).FirstOrDefault();
+
+            if (null != matchingSchema)
+                return matchingSchema;
+
+            if (generateNewElements)
+            {
+                var newSchema = new Schema() { Namespace = ns };
+                edmx.DataServices.Schemas.Add(newSchema);
+                return newSchema;
+            }
+
+            return null;
+        }
+
+        private void AddResourceToSchema(
+            Schema schema,
+            ResourceDefinition resource,
+            EntityFramework edmx,
+            IssueLogger issues,
+            bool generateNewElements = true)
+        {
+            ComplexType type = null;
+            var typeName = resource.Name.TypeOnly();
+
+            // First check to see if there is an existing resource that matches this resource in the framework already
+            var existingEntity = (from e in schema.EntityTypes where e.Name == typeName select e).SingleOrDefault();
+            if (existingEntity != null)
+            {
+                type = existingEntity;
+            }
+
+            // If that didn't work, look for a complex type that matches
+            if (type == null)
+            {
+                var existingComplexType = (from e in schema.ComplexTypes where e.Name == typeName select e).SingleOrDefault();
+                if (existingComplexType != null)
+                {
+                    type = existingComplexType;
+                }
+            }
+
+            // Finally go ahead and create a new resource in the schema if we didn't find a matching one
+            if (null == type && generateNewElements)
+            {
+                type = CreateResourceInSchema(schema, resource, issues);
+            }
+            else if (null == type)
+            {
+                issues.Error(ValidationErrorCode.ResourceTypeNotFound, $"Type {resource.Name} was in the documentation but not found in the schema.");
+            }
+
+            if (null != type)
+            {
+                LogIfDifferent(type.Name, resource.Name.TypeOnly(), issues, $"Schema type {type.Name} is different than the documentation name {resource.Name.TypeOnly()}.");
+                LogIfDifferent(type.OpenType, resource.OriginalMetadata.IsOpenType, issues, $"Schema type {type.Name} has a different OpenType value {type.OpenType} than the documentation {resource.OriginalMetadata.IsOpenType}.");
+                LogIfDifferent(type.BaseType, resource.OriginalMetadata.BaseType, issues, $"Schema type {type.Name} has a different BaseType value {type.BaseType} than the documentation {resource.OriginalMetadata.BaseType}.");
+
+                AddDocPropertiesToSchemaResource(type, resource, edmx, generateNewElements, issues);
+            }
+        }
+
+        private void AddDocPropertiesToSchemaResource(
+            ComplexType schemaType,
+            ResourceDefinition docResource,
+            EntityFramework edmx,
+            bool generateNewElements,
+            IssueLogger issues)
+        {
+            var docProps = (from p in docResource.Parameters
+                            where !p.IsNavigatable &&
+                                  !p.Name.StartsWith("@") &&
+                                  (docResource.ResolvedBaseTypeReference == null ||
+                                   !docResource.ResolvedBaseTypeReference.HasOrInheritsProperty(p.Name))
+                            select p).ToList();
+            MergePropertiesIntoSchema(schemaType.Name, schemaType.Properties, docProps, edmx, generateNewElements, issues.For(schemaType.Name), schemaType.Contributors);
+
+            var schemaEntity = schemaType as EntityType;
+
+            var docNavigationProps = (from p in docResource.Parameters
+                                      where p.IsNavigatable &&
+                                            !p.Name.StartsWith("@") &&
+                                            (docResource.ResolvedBaseTypeReference == null ||
+                                             !docResource.ResolvedBaseTypeReference.HasOrInheritsProperty(p.Name))
+                                      select p);
+
+            if (schemaEntity != null)
+            {
+                MergePropertiesIntoSchema(schemaEntity.Name, schemaEntity.NavigationProperties, docNavigationProps, edmx, generateNewElements, issues.For(schemaEntity.Name), schemaEntity.Contributors);
+            }
+
+            if (schemaType.BaseType != docResource.BaseType)
+            {
+                issues.Warning(ValidationErrorCode.Unknown, $"Resource {schemaType.Name} has multiple declarations with mismatched BaseTypes.");
+
+                if (schemaType.BaseType == null)
+                {
+                    schemaType.BaseType = docResource.BaseType;
+                }
+            }
+
+            if (schemaType.OpenType != docResource.OriginalMetadata?.IsOpenType && docResource.OriginalMetadata?.IsOpenType == true)
+            {
+                issues.Warning(ValidationErrorCode.Unknown, $"Resource { schemaType.Name} has multiple declarations with mismatched OpenType declarations.");
+                schemaType.OpenType = true;
+            }
+
+            var docInstanceAnnotations = (from p in docResource.Parameters where p.Name != null && p.Name.StartsWith("@") select p);
+            MergeInstanceAnnotationsAndRecordTerms(schemaType.Name, docInstanceAnnotations, docResource, edmx, generateNewElements);
+
+            schemaType.Contributors.Add(docResource);
+        }
+
+        private void MergePropertiesIntoSchema<TProp>(
+            string typeName,
+            List<TProp> schemaProps,
+            IEnumerable<ParameterDefinition> docProps,
+            EntityFramework edmx,
+            bool generateNewElements,
+            IssueLogger issues,
+            HashSet<ResourceDefinition> allContributors = null)
+            where TProp : Property, new()
+        {
+            var documentedProperties = docProps.ToDictionary(x => x.Name, x => x);
+            foreach (var schemaProp in schemaProps)
+            {
+                ParameterDefinition documentedVersion = null;
+                if (documentedProperties.TryGetValue(schemaProp.Name, out documentedVersion))
+                {
+                    // Compare / update schema with data from documentation
+                    var docProp = ConvertParameterToProperty<Property>(typeName, documentedVersion, issues.For(schemaProp.Name));
+                    LogIfDifferent(schemaProp.Nullable, docProp.Nullable, issues, $"Type {typeName}: Property {docProp.Name} has a different nullable value than documentation.");
+                    LogIfDifferent(schemaProp.TargetEntityType, docProp.TargetEntityType, issues, $"Type {typeName}: Property {docProp.Name} has a different target entity type than documentation.");
+                    LogIfDifferent(schemaProp.Type, docProp.Type, issues, $"Type {typeName}: Property {docProp.Name} has a different Type value than documentation ({schemaProp.Type},{docProp.Type}).");
+                    LogIfDifferent(schemaProp.Unicode, docProp.Unicode, issues, $"Type {typeName}: Property {docProp.Name} has a different unicode value than documentation ({schemaProp.Unicode},{docProp.Unicode}).");
+                    documentedProperties.Remove(documentedVersion.Name);
+
+                    AddDescriptionAnnotation(typeName, schemaProp, documentedVersion, issues);
+                }
+                else
+                {
+                    // Log out that this property wasn't in the documentation
+                    if (allContributors == null ||
+                        allContributors.All(c => c.Parameters.All(p => p.Name != schemaProp.Name)))
+                    {
+                        issues.Warning(ValidationErrorCode.RequiredPropertiesMissing,
+                            $"UndocumentedProperty: {typeName} defines {schemaProp.Name} in the schema but has no matching documentation.");
+                    }
+                }
+            }
+
+            if (generateNewElements)
+            {
+                foreach (var newPropDef in documentedProperties.Values)
+                {
+                    // Create new properties based on the documentation
+                    var newProp = ConvertParameterToProperty<TProp>(typeName, newPropDef, issues.For(newPropDef.Name));
+                    schemaProps.Add(newProp);
+                }
+            }
+        }
+
+        private static void LogIfDifferent(object schemaValue, object documentationValue, IssueLogger issues, string errorString)
+        {
+            if ((schemaValue == null && documentationValue != null) ||
+                 (schemaValue != null && documentationValue == null) ||
+                 (schemaValue != null && documentationValue != null && !schemaValue.Equals(documentationValue)))
+            {
+                issues.Warning(ValidationErrorCode.Unknown, errorString);
+            }
+        }
+
+        private ComplexType CreateResourceInSchema(Schema schema, ResourceDefinition resource, IssueLogger issues)
+        {
+            var entityKey = resource.ExplicitOrInheritedKeyPropertyName;
+            ComplexType type;
+
+            // Create a new entity or complex type for this resource
+            if (!string.IsNullOrEmpty(entityKey))
+            {
+                var entity = new EntityType
+                {
+                    BaseType = resource.BaseType,
+                    HasStream = resource.OriginalMetadata.IsMediaEntity,
+                    Name = resource.Name.TypeOnly(),
+                    Namespace = resource.Name.NamespaceOnly(),
+                    OpenType = resource.OriginalMetadata.IsOpenType,
+                };
+
+                if (resource.ResolvedBaseTypeReference == null ||
+                    entityKey != resource.ResolvedBaseTypeReference.ExplicitOrInheritedKeyPropertyName)
+                {
+                    entity.Key = new Key { PropertyRef = new PropertyRef { Name = entityKey } };
+                }
+
+                entity.NavigationProperties = (from p in resource.Parameters
+                                               where p.IsNavigatable &&
+                                                    (resource.ResolvedBaseTypeReference == null ||
+                                                    !resource.HasOrInheritsProperty(p.Name))
+                                               select ConvertParameterToProperty<NavigationProperty>(entity.Name, p, issues.For(p.Name))).ToList();
+                schema.EntityTypes.Add(entity);
+                type = entity;
+            }
+            else
+            {
+                type = new ComplexType
+                {
+                    BaseType = resource.BaseType,
+                    Name = resource.Name.TypeOnly(),
+                    Namespace = resource.Name.NamespaceOnly(),
+                    OpenType = resource.OriginalMetadata.IsOpenType,
+                };
+
+                schema.ComplexTypes.Add(type);
+            }
+
+            type.Abstract = resource.Abstract;
+            type.Contributors.Add(resource);
+
+            return type;
+        }
+
+        private void MergeInstanceAnnotationsAndRecordTerms(string typeName, IEnumerable<ParameterDefinition> annotations, ResourceDefinition containedResource, EntityFramework edmx, bool generateNewElements)
+        {
+            foreach (var prop in annotations)
+            {
+                var qualifiedName = prop.Name.Substring(1);
+                var ns = qualifiedName.NamespaceOnly();
+                var localName = qualifiedName.TypeOnly();
+
+                Term term = new Term { Name = localName, AppliesTo = containedResource.Name, Type = prop.Type.ODataResourceName() };
+                if (!string.IsNullOrEmpty(prop.Description))
+                {
+                    term.Annotations.Add(new Annotation { Term = Term.LongDescriptionTerm, String = prop.Description.ToStringClean() });
+                }
+
+                var targetSchema = FindOrCreateSchemaForNamespace(ns, edmx, overrideNamespaceFilter: true, generateNewElements: generateNewElements);
+                if (null != targetSchema)
+                {
+                    targetSchema.Terms.Add(term);
+                }
+            }
+        }
+
+        private T ConvertParameterToProperty<T>(string typeName, ParameterDefinition param, IssueLogger issues) where T : Property, new()
+        {
+            var prop = new T()
+            {
+                Name = param.Name,
+                Nullable = (param.Required.HasValue ? !param.Required.Value : false),
+                Type = param.Type.ODataResourceName()
+            };
+
+            // Add description annotation
+            AddDescriptionAnnotation(typeName, prop, param, issues);
+            return prop;
+        }
+
+        private void AddDescriptionAnnotation<T>(
+            string typeName,
+            T targetProperty,
+            ParameterDefinition sourceParameter,
+            IssueLogger issues,
+            string termForDescription = Term.DescriptionTerm) where T : Property, IODataAnnotatable
+        {
+            if (this.options.Annotations == AnnotationOptions.None)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(sourceParameter.Description))
+            {
+                if (targetProperty.Annotation == null)
+                {
+                    targetProperty.Annotation = new List<Annotation>();
+                }
+
+                // Check to see if there already is a term with Description
+                var descriptionTerm = targetProperty.Annotation.Where(t => t.Term == termForDescription).FirstOrDefault();
+                if (descriptionTerm != null)
+                {
+                    LogIfDifferent(descriptionTerm.String, sourceParameter.Description, issues, $"Type {typeName} has a different value for term '{termForDescription}' than the documentation.");
+                }
+                else
+                {
+                    targetProperty.Annotation.Add(
+                    new Annotation()
+                    {
+                        Term = termForDescription,
+                        String = sourceParameter.Description.ToStringClean(),
+                    });
+                }
+            }
+        }
+
+        private class EnumComparer : IEqualityComparer<EnumerationDefinition>
+        {
+            public bool Equals(EnumerationDefinition x, EnumerationDefinition y)
+            {
+                if (object.ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
+                if (x == null || y == null)
+                {
+                    return false;
+                }
+
+                return x.MemberName.Equals(y.MemberName);
+            }
+
+            public int GetHashCode(EnumerationDefinition obj)
+            {
+                return obj?.MemberName.GetHashCode() ?? 0;
+            }
+        }
+        private static void AddEntitySourceMethods(EntityFramework edmx, MethodCollection methodCollection, string path)
+        {
+            if (EntitySetPathRegEx.IsMatch(path))
+            {
+                var matches = EntitySetPathRegEx.Matches(path);
+                var name = matches[0].Groups[1].Value;
+                edmx.AddSetSourceMethods(methodCollection, x => x.EntitySets, name);
+            }
+        }
+
+        private static void AddSingletonSourceMethods(EntityFramework edmx, MethodCollection methodCollection, string path)
+        {
+            if (SingletonPathRegEx.IsMatch(path))
+            {
+                var matches = FullSingletonPathRegEx.Matches(path);
+                var name = matches[0].Groups[1].Value;
+                edmx.AddSetSourceMethods(methodCollection, x => x.Singletons, name);
+                edmx.AddSetSourceMethods(methodCollection, x => x.EntitySets, name);
+            }
+        }
+
+        private void AddSourceMethods(EntityFramework edmx, string[] baseUrlsToRemove, IssueLogger issues)
+        {
+            Dictionary<string, MethodCollection> uniqueRequestPaths = GetUniqueRequestPaths(baseUrlsToRemove, issues);
+            var resourcePaths = uniqueRequestPaths.Keys.OrderBy(x => x).ToArray();
+
+            foreach (var path in resourcePaths)
+            {
+                try
+                {
+                    var methodCollection = uniqueRequestPaths[path];
+                    AddEntitySourceMethods(edmx, methodCollection, path);
+                    AddSingletonSourceMethods(edmx, methodCollection, path);
+                }
+                catch (Exception ex)
+                {
+                    issues.Error(ValidationErrorCode.Unknown, $"BuildEntityContainer: error in path {path}", ex);
+                }
+            }
+        }
+        
         private static void AddRestrictionAnnotations(Dictionary<string, Annotations> annotationsMap, ISet set, MethodCollection methods, string target, IssueLogger issues)
         {
             if (methods != null)
@@ -646,1353 +1765,26 @@ namespace ApiDoctor.Publishing.CSDL
                 }
             }
         }
-
-        private static void AddHttpRequestsAnnotations(IODataAnnotatable annotatable, MethodCollection methods, IssueLogger issues)
-        {
-            if (methods != null)
-            {
-                var annotation = new Annotation
-                {
-                    Term = "Org.OData.Core.V1.HttpRequests",
-                    Collection = new RecordCollection { Records = new List<Record>() }
-                };
-
-                foreach (var method in methods)
-                {
-                    try
-                    {
-                        var record = GenerateHttpRequestMethodAnnotation(method, issues);
-                        annotation.Collection.Records.Add(record);
-                    }
-                    catch (Exception ex)
-                    {
-                        issues.Error(ValidationErrorCode.Unknown,
-                            $"Exception in {method.SourceFile.DisplayName}!", ex);
-                    }
-                }
-
-                if (annotatable.Annotation == null)
-                {
-                    annotatable.Annotation = new List<Annotation>();
-                }
-
-                annotatable.Annotation.Add(annotation);
-            }
-        }
-
-        private static Record GenerateHttpRequestMethodAnnotation(MethodDefinition method, IssueLogger issues)
-        {
-            HttpRequest request;
-            HttpParser.TryParseHttpRequest(method.Request, out request, issues);
-            HttpResponse response;
-            HttpParser.TryParseHttpResponse(method.ExpectedResponse, out response, issues);
-            var record = new Record
-            {
-                PropertyValues = new List<PropertyValue>
-                {
-                    new PropertyValue {Property = "Description", String = method.Description.ToStringClean(),},
-                    new PropertyValue {Property = "MethodDescription", String = method.Title},
-                    new PropertyValue {Property = "MethodType", String = method.HttpMethodVerb()},
-                    new PropertyValue
-                    {
-                        Property = "CustomHeaders",
-                        Collection = new RecordCollection
-                        {
-                            Records = (method.Parameters?.Where(p => p.Location == ParameterLocation.Header)?.Select(
-                                p =>
-                                    new Record
-                                    {
-                                        PropertyValues = new List<PropertyValue>
-                                        {
-                                            new PropertyValue {Property = "Name", String = p.Name},
-                                            new PropertyValue
-                                            {
-                                                Property = "Description",
-                                                String = p.Description.ToStringClean()
-                                            },
-                                            new PropertyValue
-                                            {
-                                                Property = "Required", Bool = p.Required.GetValueOrDefault()
-                                            },
-                                        }
-                                    }))?.ToList()
-                        },
-                    },
-                    new PropertyValue
-                    {
-                        Property = "CustomQueryOptions",
-                        Collection = new RecordCollection
-                        {
-                            Records = (method.Parameters?.Where(p => p.Location == ParameterLocation.QueryString)
-                                ?.Select(p =>
-                                    new Record
-                                    {
-                                        PropertyValues = new List<PropertyValue>
-                                        {
-                                            new PropertyValue {Property = "Name", String = p.Name},
-                                            new PropertyValue
-                                            {
-                                                Property = "Description", String = p.Type.ToStringClean()
-                                            },
-                                            new PropertyValue
-                                            {
-                                                Property = "Required", Bool = p.Required.GetValueOrDefault()
-                                            },
-                                        }
-                                    }))?.ToList()
-                        },
-                    },
-                    new PropertyValue
-                    {
-                        Property = "HttpResponses",
-                        Collection = new RecordCollection
-                        {
-                            Records = new List<Record>
-                            {
-                                new Record
-                                {
-                                    PropertyValues = new List<PropertyValue>
-                                    {
-                                        new PropertyValue
-                                        {
-                                            Property = "ResponseCode", String = response?.StatusCode.ToString()
-                                        },
-                                        new PropertyValue
-                                        {
-                                            Property = "Examples",
-                                            Collection = new RecordCollection
-                                            {
-                                                Records = new List<Record>
-                                                {
-                                                    new Record
-                                                    {
-                                                        Type =
-                                                            "Org.OData.Core.V1.InlineExample",
-                                                        PropertyValues =
-                                                            new List<PropertyValue>
-                                                            {
-                                                                new
-                                                                    PropertyValue
-                                                                    {
-                                                                        Property =
-                                                                            "InlineValue",
-                                                                        String =
-                                                                            response
-                                                                                ?.Body,
-                                                                    },
-                                                                new
-                                                                    PropertyValue
-                                                                    {
-                                                                        Property =
-                                                                            "Description",
-                                                                        String =
-                                                                            response
-                                                                                ?.ContentType
-                                                                    },
-                                                            }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    new PropertyValue
-                    {
-                        Property = "SecuritySchemes",
-                        Collection = new RecordCollection
-                        {
-                            Records = (method?.SourceFile?.AuthScopes?.Where(scp =>
-                                scp?.Scope != null && !scp.Scope.IContains("not supported")).Select(scp =>
-                                new Record
-                                {
-                                    PropertyValues = new List<PropertyValue>
-                                    {
-                                        new PropertyValue {Property = "AuthorizationSchemeName", String = scp.Title},
-                                        new PropertyValue
-                                        {
-                                            Property = "RequiredScopes",
-                                            Collection = new RecordCollection
-                                            {
-                                                Strings = scp.Scope?.Split(new[] {',', ';', ' '},
-                                                    StringSplitOptions.RemoveEmptyEntries).ToList()
-                                            }
-                                        }
-                                    }
-                                }))?.ToList()
-                        },
-                    },
-                },
-            };
-
-            return record;
-        }
-        private static void MergeAnnotations(string fullName, IODataAnnotatable annotatable, Dictionary<string, Annotations> schemaLevelAnnotations)
-        {
-            if (annotatable.Annotation?.Count > 0)
-            {
-                Annotations annotations;
-                if (schemaLevelAnnotations.TryGetValue(fullName, out annotations))
-                {
-                    foreach (var annotation in annotatable.Annotation)
-                    {
-                        var existingAnnotation =
-                            annotations.AnnotationList.FirstOrDefault(a => a.Term == annotation.Term);
-                        if (existingAnnotation != null && annotation.Collection != null &&
-                            annotation.Collection.Records?.Count > 0)
-                        {
-                            if (existingAnnotation.Collection == null)
-                            {
-                                existingAnnotation.Collection = new RecordCollection();
-                            }
-
-                            if (existingAnnotation.Collection.Records == null)
-                            {
-                                existingAnnotation.Collection.Records = new List<Record>();
-                            }
-
-                            existingAnnotation.Collection.Records.AddRange(annotation.Collection.Records);
-                        }
-                        else
-                        {
-                            annotations.AnnotationList.Add(annotation);
-                        }
-                    }
-                }
-                else
-                {
-                    schemaLevelAnnotations[fullName] = new Annotations
-                    {
-                        Target = fullName,
-                        AnnotationList = annotatable.Annotation,
-                    };
-                }
-
-                annotatable.Annotation = null;
-            }
-        }
-
-        /// <summary>
-        /// Scan the MethodDefintions in the documentation and create actions and functions in the
-        /// EntityFramework for matching call patterns.
-        /// </summary>
-        /// <param name="edmx"></param>
-        private void ProcessRestRequestPaths(EntityFramework edmx, string[] baseUrlsToRemove, IssueLogger issues)
-        {
-            Dictionary<string, MethodCollection> uniqueRequestPaths = GetUniqueRequestPaths(baseUrlsToRemove, issues);
-            List<string> pathsToProcess =
-                uniqueRequestPaths.Keys.OrderBy(p => p.Count(c => c == '/')).ThenBy(p => p).ToList();
-
-            for (int attempts = 1; attempts < 10 && pathsToProcess.Count > 0; attempts++)
-            {
-                Dictionary<string, Exception> pathsToRetry = new Dictionary<string, Exception>();
-                foreach (var path in pathsToProcess)
-                {
-                    var methodCollection = uniqueRequestPaths[path];
-
-                    ODataTargetInfo requestTarget = null;
-                    try
-                    {
-                        // TODO: If we have an input Edmx, we may already know what this so we don't need to infer anything.
-                        // if that is the case, we should just update it with anything else we know from the documentation.
-                        requestTarget = ParseRequestTargetType(path, methodCollection, edmx, issues);
-                        if (requestTarget.Classification == ODataTargetClassification.Unknown &&
-                            !string.IsNullOrEmpty(requestTarget.Name) &&
-                            requestTarget.QualifiedType != null)
-                        {
-                            CreateNewActionOrFunction(edmx, methodCollection, requestTarget.Name,
-                                requestTarget.QualifiedType, issues.For(requestTarget.Name));
-                        }
-                        else if (requestTarget.Classification == ODataTargetClassification.EntityType)
-                        {
-                            // We've learned more about this entity type, let's add that information to the state
-                            AppendToEntityType(edmx, requestTarget, methodCollection);
-                        }
-                        else if (requestTarget.Classification == ODataTargetClassification.NavigationProperty)
-                        {
-                            // TODO: Record somewhere the operations that are available on this NavigationProperty
-                            AppendToNavigationProperty(edmx, requestTarget, methodCollection, issues);
-                        }
-                        else
-                        {
-                            // TODO: Are there interesting things to learn here?
-                            //Console.WriteLine("Found type {0}: {1}", requestTarget.Classification, path);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        pathsToRetry.Add(path, ex);
-                        continue;
-                    }
-                }
-
-                if (pathsToRetry.Count < pathsToProcess.Count)
-                {
-                    pathsToProcess = pathsToRetry.Keys.ToList();
-                }
-                else
-                {
-                    issues.Message($"Failed to resolve the following paths after {attempts} attempts:");
-                    foreach (var kvp in pathsToRetry)
-                    {
-                        issues.Warning(ValidationErrorCode.Unknown,
-                            $"Couldn't serialize request for path {kvp.Key} into EDMX", kvp.Value);
-                    }
-
-                    break;
-                }
-            }
-        }
-
-        private void AppendToNavigationProperty(EntityFramework edmx, ODataTargetInfo navigationProperty, MethodCollection methods, IssueLogger issues)
-        {
-            EntityType parentType = edmx.ResourceWithIdentifier<EntityType>(navigationProperty.QualifiedType);
-
-            var matchingProperty =
-                parentType.NavigationProperties.FirstOrDefault(np => np.Name == navigationProperty.Name) ??
-                parentType.Properties.FirstOrDefault(p => p.Name == navigationProperty.Name);
-            if (null != matchingProperty)
-            {
-                // TODO: Append information from methods into this navigation property
-                StringBuilder sb = new StringBuilder();
-                const string seperator = ", ";
-                sb.AppendWithCondition(methods.GetAllowed, "GET", seperator);
-                sb.AppendWithCondition(methods.PostAllowed, "POST", seperator);
-                sb.AppendWithCondition(methods.PutAllowed, "PUT", seperator);
-                sb.AppendWithCondition(methods.DeleteAllowed, "DELETE", seperator);
-                issues.Message(
-                    $"Collection '{navigationProperty.QualifiedType + "/" + navigationProperty.Name}' supports: ({sb})");
-            }
-            else
-            {
-                issues.Error(ValidationErrorCode.RequiredPropertiesMissing,
-                    $"EntityType '{navigationProperty.QualifiedType}' doesn't have a matching Property '{navigationProperty.Name}' but a request exists for this. Sounds like a documentation error.");
-            }
-        }
-
-        /// <summary>
-        /// Use the properties of methodCollection to augment what we know about this entity type
-        /// </summary>
-        /// <param name="requestTarget"></param>
-        /// <param name="methodCollection"></param>
-        private void AppendToEntityType(EntityFramework edmx, ODataTargetInfo requestTarget, MethodCollection methodCollection)
-        {
-            StringBuilder sb = new StringBuilder();
-            const string seperator = ", ";
-            sb.AppendWithCondition(methodCollection.GetAllowed, "GET", seperator);
-            sb.AppendWithCondition(methodCollection.PostAllowed, "POST", seperator);
-            sb.AppendWithCondition(methodCollection.PutAllowed, "PUT", seperator);
-            sb.AppendWithCondition(methodCollection.DeleteAllowed, "DELETE", seperator);
-        }
-
-        private void CreateNewActionOrFunction(
-            EntityFramework edmx,
-            MethodCollection methodCollection,
-            string name,
-            string boundToType,
-            IssueLogger issues,
-            bool recursing = false)
-        {
-            if (name.IEquals("$ref") ||
-                name.IEquals("$value"))
-            {
-                issues.Message("Ignoring $ref and $value. No schema changes needed.");
-                return;
-            }
-
-            if (name.StartsWith("{"))
-            {
-                var currentType = edmx.DataServices.Schemas.FindTypeWithIdentifier(boundToType) as ComplexType;
-                if (currentType?.OpenType == true)
-                {
-                    issues.Message($"Ignoring {name} navigation into open type. No schema changes needed.");
-                }
-                else
-                {
-                    issues.Warning(ValidationErrorCode.Unknown,
-                        $"Don't know what to do with {name}; it's not a function");
-                }
-
-                return;
-            }
-
-            // Create a new action (not idempotent) / function (idempotent) based on this request method!
-            ActionOrFunctionBase target = null;
-            if (methodCollection.AllMethodsIdempotent)
-            {
-                target = new Validation.OData.Function
-                {
-                    IsComposable = methodCollection.Any(mc => mc.RequestMetadata.IsComposable),
-                };
-            }
-            else
-            {
-                target = new Validation.OData.Action();
-            }
-
-            if (this.options.ShowSources)
-            {
-                target.SourceFiles = string.Join(";",
-                    new HashSet<string>(methodCollection.Select(m => m.SourceFile)
-                        .Select(f => Path.GetFileName(f.FullPath)).ToList()));
-            }
-
-            if (this.options.Annotations.HasFlag(AnnotationOptions.HttpRequests))
-            {
-                AddHttpRequestsAnnotations(target, methodCollection, issues.For(name));
-            }
-
-            target.SourceMethods = methodCollection;
-
-            target.Name = name.TypeOnly();
-            target.IsBound = true;
-            target.Parameters.Add(new Parameter { Name = "bindingParameter", Type = boundToType, IsNullable = false });
-            foreach (var param in methodCollection.Where(m => m.HttpMethodVerb() == "POST")
-                         .SelectMany(m => m.RequestBodyParameters))
-            {
-                try
-                {
-                    var existingParam = target.Parameters.FirstOrDefault(p => p.Name.IEquals(param.Name));
-                    if (existingParam != null)
-                    {
-                        existingParam.Type =
-                            ParameterDataType.ChooseBest(existingParam.Type, param.Type.ODataResourceName());
-                    }
-                    else
-                    {
-                        target.Parameters.Add(
-                            new Parameter
-                            {
-                                Name = param.Name,
-                                Type = param.Type.ODataResourceName(),
-                                IsNullable = (param.Required.HasValue ? param.Required.Value : false)
-                            });
-                    }
-                }
-                catch (Exception ex)
-                {
-                    issues.Error(ValidationErrorCode.Unknown,
-                        $"Exception when adding parameter {param.Name} with type {param.Type}", ex);
-                    throw;
-                }
-            }
-
-            if (target.Name.Contains("("))
-            {
-                target.ParameterizedName = target.Name;
-                var pathParameters = target.Name.TextBetweenCharacters('(', ')').Split(',');
-                target.Name = target.Name.Substring(0, target.Name.IndexOf('('));
-                foreach (var param in pathParameters.Where(p => !string.IsNullOrEmpty(p)))
-                {
-                    var paramName = param.Split('=')[0];
-                    var matchingParamDef = methodCollection.SelectMany(m => m.Parameters)
-                        .FirstOrDefault(p => p.Name == paramName);
-                    if (matchingParamDef == null)
-                    {
-                        issues.Error(ValidationErrorCode.Unknown,
-                            $"Couldn't find definition for parameter {param} in {name} after looking in {string.Join(",", methodCollection.Select(m => m.SourceFile?.DisplayName))}");
-                    }
-                    else
-                    {
-                        target.Parameters.Add(
-                            new Parameter
-                            {
-                                Name = matchingParamDef.Name,
-                                Type = matchingParamDef.Type.ODataResourceName(),
-                                IsNullable = (matchingParamDef.Required.GetValueOrDefault())
-                            });
-
-                        // if we have an optional param, recursively call again without it
-                        if (matchingParamDef.Optional.GetValueOrDefault() == true)
-                        {
-                            var overloadName = target.ParameterizedName.Replace($"{paramName}={{var}}", string.Empty);
-                            CreateNewActionOrFunction(edmx, methodCollection, overloadName, boundToType, issues);
-                        }
-                    }
-                }
-
-                if (!recursing)
-                {
-                    // note: this is very rough and brittle. only intended for limited use right now.
-                    // if there are other sample calling patterns for this function, create bindings for them too.
-                    foreach (var sample in methodCollection.SelectMany(mc => mc.SourceFile.Samples)
-                                 .SelectMany(s => s.Samples))
-                    {
-                        if (sample.EndsWith(")") && sample.Contains("("))
-                        {
-                            var overloadName =
-                                target.ParameterizedName.ReplaceTextBetweenCharacters('(', ')',
-                                    sample.TextBetweenCharacters('(', ')'));
-                            CreateNewActionOrFunction(edmx, methodCollection, overloadName, boundToType, issues,
-                                recursing: true);
-                        }
-                        else if (sample.EndsWith(target.Name))
-                        {
-                            // overload with no parameters
-                            var overloadName = target.Name;
-                            CreateNewActionOrFunction(edmx, methodCollection, overloadName, boundToType, issues,
-                                recursing: true);
-                        }
-                    }
-                }
-            }
-
-            if (methodCollection.ResponseType != null)
-            {
-                target.ReturnType = new ReturnType
-                {
-                    Type = methodCollection.ResponseType.ODataResourceName(),
-                    Nullable = false
-                };
-                var targetAction = target as Validation.OData.Action;
-                if (targetAction != null &&
-                    target.Parameters.FirstOrDefault(p => p.Name == "bindingParameter")?.Type
-                        ?.StartsWith("Collection(") == false)
-                {
-                    targetAction.EntitySetPath = "bindingParameter";
-                }
-            }
-
-            var schemaName = name.HasNamespace()
-                ? name.NamespaceOnly()
-                : edmx.DataServices.Schemas.FirstOrDefault()?.Namespace;
-            var schema = FindOrCreateSchemaForNamespace(schemaName, edmx, true);
-
-            // first see if this action or function is already bound to a base type with the same params.
-            // if so, this definition is redundant.
-            foreach (var existingFunction in schema.Functions.Cast<ActionOrFunctionBase>().Concat(schema.Actions)
-                         .ToList())
-            {
-                if (existingFunction.CanSubstituteFor(target, edmx))
-                {
-                    return;
-                }
-
-                // on the other hand, if the opposite is true...
-                if (target.CanSubstituteFor(existingFunction, edmx))
-                {
-                    if (target is Function)
-                    {
-                        schema.Functions.Remove((Function)existingFunction);
-                    }
-                    else
-                    {
-                        schema.Actions.Remove((Validation.OData.Action)existingFunction);
-                    }
-                }
-            }
-
-            if (target is Function)
-            {
-                schema.Functions.Add((Function)target);
-            }
-            else
-            {
-                schema.Actions.Add((Validation.OData.Action)target);
-            }
-        }
-
-        /// <summary>
-        /// Walks the requestPath through the resources / entities defined in the edmx and resolves
-        /// the type of request represented by the path
-        /// </summary>
-        /// <param name="requestPath"></param>
-        /// <param name="requestMethod"></param>
-        /// <param name="edmx"></param>
-        /// <returns></returns>
-        private static ODataTargetInfo ParseRequestTargetType(string requestPath,
-            MethodCollection requestMethodCollection, EntityFramework edmx, IssueLogger issues)
-        {
-            string[] requestParts = requestPath.Substring(1).Split(new char[] { '/' });
-
-            EntityContainer entryPoint = (from s in edmx.DataServices.Schemas
-                                          where s.EntityContainers.Count > 0
-                                          select s.EntityContainers.FirstOrDefault()).SingleOrDefault();
-
-            if (entryPoint == null)
-                throw new InvalidOperationException("Couldn't locate an EntityContainer to begin target resolution");
-
-            IODataNavigable currentObject = entryPoint;
-            IODataNavigable previousObject = null;
-
-            for (int i = 0; i < requestParts.Length; i++)
-            {
-                bool isLastSegment = i == requestParts.Length - 1;
-                string uriPart = requestParts[i];
-                IODataNavigable nextObject = null;
-                if (uriPart == "{var}" &&
-                    (currentObject as ComplexType)?.OpenType != true)
-                {
-                    try
-                    {
-                        nextObject = currentObject.NavigateByEntityTypeKey(edmx,
-                            issues.For($"ExampleRequest_{string.Join("/", requestParts.Take(i + 1))}"));
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new NotSupportedException("Unable to navigation into EntityType by key: " +
-                                                        currentObject.TypeIdentifier + " (" + ex.Message + ")");
-                    }
-                }
-                else
-                {
-                    nextObject = currentObject.NavigateByUriComponent(
-                        uriPart,
-                        edmx,
-                        issues.For($"ExampleRequest_{string.Join("/", requestParts.Take(i + 1))}"),
-                        isLastSegment);
-                }
-
-                if (nextObject == null && isLastSegment)
-                {
-                    // The last component wasn't known already, so that means we have a new thing.
-
-                    return new ODataTargetInfo
-                    {
-                        Name = uriPart,
-                        Classification = ODataTargetClassification.Unknown,
-                        QualifiedType = edmx.LookupIdentifierForType(currentObject)
-                    };
-                }
-                else if (nextObject == null)
-                {
-                    throw new InvalidOperationException(
-                        $"Uri path requires navigating into unknown object hierarchy: missing property '{uriPart}' on '{currentObject.TypeIdentifier}'. Possible issues:\r\n" +
-                        $"\t 1) Doc bug where '{uriPart}' isn't defined on the resource.\r\n" +
-                        $"\t 2) Doc bug where '{uriPart}' is an example key and should instead be replaced with a placeholder like {{item-id}} or declared in the sampleKeys annotation.\r\n" +
-                        $"\t 3) Doc bug where '{currentObject.TypeIdentifier}' is supposed to be an entity type, but is being treated as a complex because it (and its ancestors) are missing the keyProperty annotation.\r\n");
-                }
-
-                previousObject = currentObject;
-                currentObject = nextObject;
-            }
-
-            var response = new ODataTargetInfo
-            {
-                Name = requestParts.Last(),
-                QualifiedType = edmx.LookupIdentifierForType(currentObject)
-            };
-
-            if (currentObject is EntityType)
-                response.Classification = ODataTargetClassification.EntityType;
-            else if (currentObject is EntityContainer)
-                response.Classification = ODataTargetClassification.EntityContainer;
-            else if (currentObject is ODataSimpleType)
-                response.Classification = ODataTargetClassification.SimpleType;
-            else if (currentObject is ODataCollection)
-            {
-                if (previousObject != entryPoint)
-                {
-                    if (response.Name.Contains("."))
-                    {
-                        response.Classification = ODataTargetClassification.TypeCast;
-                    }
-                    else
-                    {
-                        response.Classification = ODataTargetClassification.NavigationProperty;
-                    }
-
-                    response.QualifiedType = edmx.LookupIdentifierForType(previousObject);
-                }
-                else
-                {
-                    response.Classification = ODataTargetClassification.EntitySet;
-                }
-            }
-            else if (currentObject is ComplexType)
-            {
-                response.Classification = ODataTargetClassification.ComplexType;
-            }
-            else
-            {
-                throw new NotSupportedException(string.Format("Unhandled object type: {0}",
-                    currentObject.GetType().Name));
-            }
-
-            return response;
-        }
-
-        // EntitySet is something in the format of /name/{var}
-        private static readonly Regex EntitySetPathRegEx = new(@"\/(\w*)\/{var}$", RegexOptions.Compiled);
-        // Singleton is something in the format of /name
-        private static readonly Regex SingletonPathRegEx = new(@"\/(\w*)$", RegexOptions.Compiled);
-        // Singleton such as /admin/serviceAnnouncements/healthOverviews
-        private static readonly Regex FullSingletonPathRegEx = new(@"\/(\w*)", RegexOptions.Compiled);
-
-        /// <summary>
-        /// Parse the URI paths for methods defined in the documentation and construct an entity container that contains these
-        /// entity sets / singletons in the largest namespace.
-        /// </summary>
-        private void BuildEntityContainer(EntityFramework edmx, string[] baseUrlsToRemove, IssueLogger issues)
-        {
-            // Check to see if an entitycontainer already exists
-            foreach (var s in edmx.DataServices.Schemas)
-            {
-                if (s.EntityContainers.Any())
-                    return;
-            }
-
-            Dictionary<string, MethodCollection> uniqueRequestPaths = GetUniqueRequestPaths(baseUrlsToRemove, issues);
-            var resourcePaths = uniqueRequestPaths.Keys.OrderBy(x => x).ToArray();
-
-            EntityContainer container = new EntityContainer();
-            foreach (var path in resourcePaths)
-            {
-                try
-                {
-                    var methodCollection = uniqueRequestPaths[path];
-
-                    if (EntitySetPathRegEx.IsMatch(path))
-                    {
-                        var name = EntitySetPathRegEx.Match(path).Groups[1].Value;
-                        var entitySet = new EntitySet
-                        {
-                            Name = name,
-                            EntityType = methodCollection.ResponseType?.ODataResourceName(),
-                            SourceMethods = methodCollection,
-                        };
-
-                        if (this.options.Annotations.HasFlag(AnnotationOptions.HttpRequests))
-                        {
-                            AddHttpRequestsAnnotations(entitySet, methodCollection,
-                                issues.For(path + "/HttpRequestsAnnotations"));
-                        }
-
-                        container.EntitySets.Add(entitySet);
-                    }
-                    else if (SingletonPathRegEx.IsMatch(path))
-                    {
-                        // Before we declare this a singleton, see if any other paths that have the same root match the entity set regex
-                        var query = (from p in resourcePaths
-                                     where p.StartsWith(path + "/") && EntitySetPathRegEx.IsMatch(p)
-                                     select p);
-                        if (query.Any())
-                        {
-                            // If there's a similar resource path that matches the entity, we don't declare a singleton.
-                            continue;
-                        }
-
-                        var name = SingletonPathRegEx.Match(path).Groups[1].Value;
-                        var singleton = new Singleton
-                        {
-                            Name = name,
-                            Type = methodCollection.ResponseType.ODataResourceName(),
-                            SourceMethods = methodCollection,
-                        };
-
-                        if (this.options.Annotations.HasFlag(AnnotationOptions.HttpRequests))
-                        {
-                            AddHttpRequestsAnnotations(singleton, methodCollection,
-                                issues.For(path + "/HttpRequestsAnnotations"));
-                        }
-
-                        container.Singletons.Add(singleton);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    issues.Error(ValidationErrorCode.Unknown, $"BuildEntityContainer: error in path {path}", ex);
-                }
-            }
-
-            Schema defaultSchema;
-            if (DocSet.SchemaConfig.DefaultNamespace != null)
-            {
-                defaultSchema =
-                    edmx.DataServices.Schemas.Single(s => s.Namespace.IEquals(DocSet.SchemaConfig.DefaultNamespace));
-            }
-            else
-            {
-                // if the default schema isn't specified, assume the most common schema in the docs is the default
-                defaultSchema = edmx.DataServices.Schemas.OrderByDescending(s => s.EntityTypes.Count).First();
-            }
-
-            container.Name = this.options.EntityContainerName ?? defaultSchema.Namespace;
-            defaultSchema.EntityContainers.Add(container);
-        }
-
-        private static void AddEntitySourceMethods(EntityFramework edmx, MethodCollection methodCollection, string path)
-        {
-            if (EntitySetPathRegEx.IsMatch(path))
-            {
-                var matches = EntitySetPathRegEx.Matches(path);
-                var name = matches[0].Groups[1].Value;
-                edmx.AddSetSourceMethods(methodCollection, x => x.EntitySets, name);
-            }
-        }
-
-        private static void AddSingletonSourceMethods(EntityFramework edmx, MethodCollection methodCollection, string path)
-        {
-            if (SingletonPathRegEx.IsMatch(path))
-            {
-                var matches = FullSingletonPathRegEx.Matches(path);
-                var name = matches[0].Groups[1].Value;
-                edmx.AddSetSourceMethods(methodCollection, x => x.Singletons, name);
-                edmx.AddSetSourceMethods(methodCollection, x => x.EntitySets, name);
-            }
-        }
-
-        private void AddSourceMethods(EntityFramework edmx, string[] baseUrlsToRemove, IssueLogger issues)
-        {
-            Dictionary<string, MethodCollection> uniqueRequestPaths = GetUniqueRequestPaths(baseUrlsToRemove, issues);
-            var resourcePaths = uniqueRequestPaths.Keys.OrderBy(x => x).ToArray();
-
-            foreach (var path in resourcePaths)
-            {
-                try
-                {
-                    var methodCollection = uniqueRequestPaths[path];
-                    AddEntitySourceMethods(edmx, methodCollection, path);
-                    AddSingletonSourceMethods(edmx, methodCollection, path);
-                }
-                catch (Exception ex)
-                {
-                    issues.Error(ValidationErrorCode.Unknown, $"BuildEntityContainer: error in path {path}", ex);
-                }
-            }
-        }
-
-        private Dictionary<string, MethodCollection> cachedUniqueRequestPaths
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Return a dictionary of the unique request paths in the
-        /// documentation and the method definitions that defined them.
-        /// </summary>
-        /// <returns></returns>
-        private Dictionary<string, MethodCollection> GetUniqueRequestPaths(string[] baseUrlsToRemove,
-            IssueLogger issues)
-        {
-            if (cachedUniqueRequestPaths == null)
-            {
-                Dictionary<string, MethodCollection> uniqueRequestPaths = new Dictionary<string, MethodCollection>();
-                foreach (var m in Documents.Methods)
-                {
-                    if (m.RequestMetadata?.OpaqueUrl == true)
-                    {
-                        // ignore requests with opaque urls, as they don't contribute to the schema
-                        continue;
-                    }
-
-                    if (m.ExpectedResponseMetadata != null && m.ExpectedResponseMetadata.ExpectError)
-                    {
-                        // Ignore things that are expected to error
-                        continue;
-                    }
-
-                    var path = m.RequestUriPathOnly(baseUrlsToRemove, issues);
-                    if (!path.StartsWith("/"))
-                    {
-                        // Ignore absolute URI paths
-                        continue;
-                    }
-
-                    if (m.RequestMetadata.Tags != null &&
-                        DocSet.SchemaConfig.SupportedTags != null &&
-                        !DocSet.SchemaConfig.SupportedTags.Intersect(m.RequestMetadata.TagList).Any())
-                    {
-                        // ignore tagged request examples if the current service doesn't support that tag
-                        continue;
-                    }
-
-                    issues.Message($"Converted '{m.Request.FirstLineOnly()}' into generic form '{path}'");
-
-                    if (!uniqueRequestPaths.ContainsKey(path))
-                    {
-                        uniqueRequestPaths.Add(path, new MethodCollection());
-                    }
-
-                    uniqueRequestPaths[path].Add(m);
-
-                    issues.Message(
-                        $"{path} :: {m.RequestMetadata.ResourceType} --> {m.ExpectedResponseMetadata?.ResourceType}");
-                }
-
-                cachedUniqueRequestPaths = uniqueRequestPaths;
-            }
-
-            return cachedUniqueRequestPaths;
-        }
-
-        /// <summary>
-        /// Find an existing schema definiton or create a new one in an entity framework for a given namespace.
-        /// </summary>
-        /// <param name="ns"></param>
-        /// <param name="edmx"></param>
-        /// <returns></returns>
-        private Schema FindOrCreateSchemaForNamespace(string ns, EntityFramework edmx,
-            bool overrideNamespaceFilter = false, bool generateNewElements = true)
-        {
-            // Check to see if this is a namespace that should be exported.
-            if (!overrideNamespaceFilter && options.Namespaces != null && !options.Namespaces.Contains(ns))
-            {
-                return null;
-            }
-
-            if (ns.Equals("odata", StringComparison.OrdinalIgnoreCase))
-            {
-                return null;
-            }
-
-            var matchingSchema = (from s in edmx.DataServices.Schemas
-                                  where s.Namespace == ns
-                                  select s).FirstOrDefault();
-
-            if (null != matchingSchema)
-                return matchingSchema;
-
-            if (generateNewElements)
-            {
-                var newSchema = new Schema() { Namespace = ns };
-                edmx.DataServices.Schemas.Add(newSchema);
-                return newSchema;
-            }
-
-            return null;
-        }
-
-        private void AddResourceToSchema(
-            Schema schema,
-            ResourceDefinition resource,
-            EntityFramework edmx,
-            IssueLogger issues,
-            bool generateNewElements = true)
-        {
-            ComplexType type = null;
-            var typeName = resource.Name.TypeOnly();
-
-            // First check to see if there is an existing resource that matches this resource in the framework already
-            var existingEntity = (from e in schema.EntityTypes where e.Name == typeName select e).SingleOrDefault();
-            if (existingEntity != null)
-            {
-                type = existingEntity;
-            }
-
-            // If that didn't work, look for a complex type that matches
-            if (type == null)
-            {
-                var existingComplexType =
-                    (from e in schema.ComplexTypes where e.Name == typeName select e).SingleOrDefault();
-                if (existingComplexType != null)
-                {
-                    type = existingComplexType;
-                }
-            }
-
-            // Finally go ahead and create a new resource in the schema if we didn't find a matching one
-            if (null == type && generateNewElements)
-            {
-                type = CreateResourceInSchema(schema, resource, issues);
-            }
-            else if (null == type)
-            {
-                issues.Error(ValidationErrorCode.ResourceTypeNotFound,
-                    $"Type {resource.Name} was in the documentation but not found in the schema.");
-            }
-
-            if (null != type)
-            {
-                LogIfDifferent(type.Name, resource.Name.TypeOnly(), issues,
-                    $"Schema type {type.Name} is different than the documentation name {resource.Name.TypeOnly()}.");
-                LogIfDifferent(type.OpenType, resource.OriginalMetadata.IsOpenType, issues,
-                    $"Schema type {type.Name} has a different OpenType value {type.OpenType} than the documentation {resource.OriginalMetadata.IsOpenType}.");
-                LogIfDifferent(type.BaseType, resource.OriginalMetadata.BaseType, issues,
-                    $"Schema type {type.Name} has a different BaseType value {type.BaseType} than the documentation {resource.OriginalMetadata.BaseType}.");
-
-                AddDocPropertiesToSchemaResource(type, resource, edmx, generateNewElements, issues);
-            }
-        }
-
-        private void AddDocPropertiesToSchemaResource(
-            ComplexType schemaType,
-            ResourceDefinition docResource,
-            EntityFramework edmx,
-            bool generateNewElements,
-            IssueLogger issues)
-        {
-            var docProps = (from p in docResource.Parameters
-                            where !p.IsNavigatable &&
-                                  !p.Name.StartsWith("@") &&
-                                  (docResource.ResolvedBaseTypeReference == null ||
-                                   !docResource.ResolvedBaseTypeReference.HasOrInheritsProperty(p.Name))
-                            select p).ToList();
-            MergePropertiesIntoSchema(schemaType.Name, schemaType.Properties, docProps, edmx, generateNewElements,
-                issues.For(schemaType.Name), schemaType.Contributors);
-
-            var schemaEntity = schemaType as EntityType;
-
-            var docNavigationProps = (from p in docResource.Parameters
-                                      where p.IsNavigatable &&
-                                            !p.Name.StartsWith("@") &&
-                                            (docResource.ResolvedBaseTypeReference == null ||
-                                             !docResource.ResolvedBaseTypeReference.HasOrInheritsProperty(p.Name))
-                                      select p);
-
-            if (schemaEntity != null)
-            {
-                MergePropertiesIntoSchema(schemaEntity.Name, schemaEntity.NavigationProperties, docNavigationProps,
-                    edmx, generateNewElements, issues.For(schemaEntity.Name), schemaEntity.Contributors);
-            }
-
-            if (schemaType.BaseType != docResource.BaseType)
-            {
-                issues.Warning(ValidationErrorCode.Unknown,
-                    $"Resource {schemaType.Name} has multiple declarations with mismatched BaseTypes.");
-
-                if (schemaType.BaseType == null)
-                {
-                    schemaType.BaseType = docResource.BaseType;
-                }
-            }
-
-            if (schemaType.OpenType != docResource.OriginalMetadata?.IsOpenType &&
-                docResource.OriginalMetadata?.IsOpenType == true)
-            {
-                issues.Warning(ValidationErrorCode.Unknown,
-                    $"Resource {schemaType.Name} has multiple declarations with mismatched OpenType declarations.");
-                schemaType.OpenType = true;
-            }
-
-            var docInstanceAnnotations =
-                (from p in docResource.Parameters where p.Name != null && p.Name.StartsWith("@") select p);
-            MergeInstanceAnnotationsAndRecordTerms(schemaType.Name, docInstanceAnnotations, docResource, edmx,
-                generateNewElements);
-
-            schemaType.Contributors.Add(docResource);
-        }
-
-        private void MergePropertiesIntoSchema<TProp>(
-            string typeName,
-            List<TProp> schemaProps,
-            IEnumerable<ParameterDefinition> docProps,
-            EntityFramework edmx,
-            bool generateNewElements,
-            IssueLogger issues,
-            HashSet<ResourceDefinition> allContributors = null)
-            where TProp : Property, new()
-        {
-            var documentedProperties = docProps.ToDictionary(x => x.Name, x => x);
-            foreach (var schemaProp in schemaProps)
-            {
-                ParameterDefinition documentedVersion = null;
-                if (documentedProperties.TryGetValue(schemaProp.Name, out documentedVersion))
-                {
-                    // Compare / update schema with data from documentation
-                    var docProp =
-                        ConvertParameterToProperty<Property>(typeName, documentedVersion, issues.For(schemaProp.Name));
-                    LogIfDifferent(schemaProp.Nullable, docProp.Nullable, issues,
-                        $"Type {typeName}: Property {docProp.Name} has a different nullable value than documentation.");
-                    LogIfDifferent(schemaProp.TargetEntityType, docProp.TargetEntityType, issues,
-                        $"Type {typeName}: Property {docProp.Name} has a different target entity type than documentation.");
-                    LogIfDifferent(schemaProp.Type, docProp.Type, issues,
-                        $"Type {typeName}: Property {docProp.Name} has a different Type value than documentation ({schemaProp.Type},{docProp.Type}).");
-                    LogIfDifferent(schemaProp.Unicode, docProp.Unicode, issues,
-                        $"Type {typeName}: Property {docProp.Name} has a different unicode value than documentation ({schemaProp.Unicode},{docProp.Unicode}).");
-                    documentedProperties.Remove(documentedVersion.Name);
-
-                    AddDescriptionAnnotation(typeName, schemaProp, documentedVersion, issues);
-                }
-                else
-                {
-                    // Log out that this property wasn't in the documentation
-                    if (allContributors == null ||
-                        allContributors.All(c => c.Parameters.All(p => p.Name != schemaProp.Name)))
-                    {
-                        issues.Warning(ValidationErrorCode.RequiredPropertiesMissing,
-                            $"UndocumentedProperty: {typeName} defines {schemaProp.Name} in the schema but has no matching documentation.");
-                    }
-                }
-            }
-
-            if (generateNewElements)
-            {
-                foreach (var newPropDef in documentedProperties.Values)
-                {
-                    // Create new properties based on the documentation
-                    var newProp = ConvertParameterToProperty<TProp>(typeName, newPropDef, issues.For(newPropDef.Name));
-                    schemaProps.Add(newProp);
-                }
-            }
-        }
-
-        private static void LogIfDifferent(object schemaValue, object documentationValue, IssueLogger issues,
-            string errorString)
-        {
-            if ((schemaValue == null && documentationValue != null) ||
-                (schemaValue != null && documentationValue == null) ||
-                (schemaValue != null && documentationValue != null && !schemaValue.Equals(documentationValue)))
-            {
-                issues.Warning(ValidationErrorCode.Unknown, errorString);
-            }
-        }
-
-        private ComplexType CreateResourceInSchema(Schema schema, ResourceDefinition resource, IssueLogger issues)
-        {
-            var entityKey = resource.ExplicitOrInheritedKeyPropertyName;
-            ComplexType type;
-
-            // Create a new entity or complex type for this resource
-            if (!string.IsNullOrEmpty(entityKey))
-            {
-                var entity = new EntityType
-                {
-                    BaseType = resource.BaseType,
-                    HasStream = resource.OriginalMetadata.IsMediaEntity,
-                    Name = resource.Name.TypeOnly(),
-                    Namespace = resource.Name.NamespaceOnly(),
-                    OpenType = resource.OriginalMetadata.IsOpenType,
-                    Annotation = new List<Annotation>
-                    {
-                        new() {Term = Term.DescriptionTerm, String = resource.Description}
-                    }
-                };
-
-                if (resource.ResolvedBaseTypeReference == null ||
-                    entityKey != resource.ResolvedBaseTypeReference.ExplicitOrInheritedKeyPropertyName)
-                {
-                    entity.Key = new Key { PropertyRef = new PropertyRef { Name = entityKey } };
-                }
-
-                entity.NavigationProperties = (from p in resource.Parameters
-                                               where p.IsNavigatable &&
-                                                     (resource.ResolvedBaseTypeReference == null ||
-                                                      !resource.HasOrInheritsProperty(p.Name))
-                                               select ConvertParameterToProperty<NavigationProperty>(entity.Name, p, issues.For(p.Name))).ToList();
-                schema.EntityTypes.Add(entity);
-                type = entity;
-            }
-            else
-            {
-                type = new ComplexType
-                {
-                    BaseType = resource.BaseType,
-                    Name = resource.Name.TypeOnly(),
-                    Namespace = resource.Name.NamespaceOnly(),
-                    OpenType = resource.OriginalMetadata.IsOpenType,
-                    Annotation = new List<Annotation>()
-                    {
-                        new() {Term = Term.DescriptionTerm, String = resource.Description,}
-                    }
-                };
-
-                schema.ComplexTypes.Add(type);
-            }
-
-            type.Abstract = resource.Abstract;
-            type.Contributors.Add(resource);
-
-            return type;
-        }
-
-        private void MergeInstanceAnnotationsAndRecordTerms(string typeName,
-            IEnumerable<ParameterDefinition> annotations, ResourceDefinition containedResource, EntityFramework edmx,
-            bool generateNewElements)
-        {
-            foreach (var prop in annotations)
-            {
-                var qualifiedName = prop.Name.Substring(1);
-                var ns = qualifiedName.NamespaceOnly();
-                var localName = qualifiedName.TypeOnly();
-
-                Term term = new Term
-                {
-                    Name = localName,
-                    AppliesTo = containedResource.Name,
-                    Type = prop.Type.ODataResourceName()
-                };
-                if (!string.IsNullOrEmpty(prop.Description))
-                {
-                    term.Annotations.Add(new Annotation
-                    {
-                        Term = Term.LongDescriptionTerm,
-                        String = prop.Description.ToStringClean()
-                    });
-                }
-
-                var targetSchema = FindOrCreateSchemaForNamespace(ns, edmx, overrideNamespaceFilter: true,
-                    generateNewElements: generateNewElements);
-                if (null != targetSchema)
-                {
-                    targetSchema.Terms.Add(term);
-                }
-            }
-        }
-
-        private T ConvertParameterToProperty<T>(string typeName, ParameterDefinition param, IssueLogger issues)
-            where T : Property, new()
-        {
-            var prop = new T()
-            {
-                Name = param.Name,
-                Nullable = (param.Required.HasValue ? !param.Required.Value : false),
-                Type = param.Type.ODataResourceName()
-            };
-
-            // Add description annotation
-            AddDescriptionAnnotation(typeName, prop, param, issues);
-            return prop;
-        }
-
-        private void AddDescriptionAnnotation<T>(
-            string typeName,
-            T targetProperty,
-            ParameterDefinition sourceParameter,
-            IssueLogger issues,
-            string termForDescription = Term.DescriptionTerm) where T : Property, IODataAnnotatable
-        {
-            if (this.options.Annotations == AnnotationOptions.None)
-            {
-                return;
-            }
-
-            if (!string.IsNullOrEmpty(sourceParameter.Description))
-            {
-                if (targetProperty.Annotation == null)
-                {
-                    targetProperty.Annotation = new List<Annotation>();
-                }
-
-                // Check to see if there already is a term with Description
-                var descriptionTerm =
-                    targetProperty.Annotation.Where(t => t.Term == termForDescription).FirstOrDefault();
-                if (descriptionTerm != null)
-                {
-                    LogIfDifferent(descriptionTerm.String, sourceParameter.Description, issues,
-                        $"Type {typeName} has a different value for term '{termForDescription}' than the documentation.");
-                }
-                else
-                {
-                    targetProperty.Annotation.Add(
-                        new Annotation()
-                        {
-                            Term = termForDescription,
-                            String = sourceParameter.Description.ToStringClean(),
-                        });
-                }
-            }
-        }
-
-        private class EnumComparer : IEqualityComparer<EnumerationDefinition>
-        {
-            public bool Equals(EnumerationDefinition x, EnumerationDefinition y)
-            {
-                if (object.ReferenceEquals(x, y))
-                {
-                    return true;
-                }
-
-                if (x == null || y == null)
-                {
-                    return false;
-                }
-
-                return x.MemberName.Equals(y.MemberName);
-            }
-
-            public int GetHashCode(EnumerationDefinition obj)
-            {
-                return obj?.MemberName.GetHashCode() ?? 0;
-            }
-        }
     }
 
 
     public class CsdlWriterOptions
     {
-        public string OutputDirectoryPath
-        {
-            get;
-            set;
-        }
-
-        public string SourceMetadataPath
-        {
-            get;
-            set;
-        }
-
-        public string MergeWithMetadataPath
-        {
-            get;
-            set;
-        }
-
-        public MetadataFormat Formats
-        {
-            get;
-            set;
-        }
-
-        public string[] Namespaces
-        {
-            get;
-            set;
-        }
-
-        public bool Sort
-        {
-            get;
-            set;
-        }
-
-        public string TransformOutput
-        {
-            get;
-            set;
-        }
-
-        public string DocumentationSetPath
-        {
-            get;
-            set;
-        }
-
-        public string Version
-        {
-            get;
-            set;
-        }
-
-        public bool SkipMetadataGeneration
-        {
-            get;
-            set;
-        }
-
-        public AnnotationOptions Annotations
-        {
-            get;
-            set;
-        }
-
-        public bool ValidateSchema
-        {
-            get;
-            set;
-        }
-
-        public bool AttributesOnNewLines
-        {
-            get;
-            set;
-        }
-
-        public string EntityContainerName
-        {
-            get;
-            set;
-        }
-
-        public bool ShowSources
-        {
-            get;
-            set;
-        }
+        public string OutputDirectoryPath { get; set; }
+        public string SourceMetadataPath { get; set; }
+        public string MergeWithMetadataPath { get; set; }
+        public MetadataFormat Formats { get; set; }
+        public string[] Namespaces { get; set; }
+        public bool Sort { get; set; }
+        public string TransformOutput { get; set; }
+        public string DocumentationSetPath { get; set; }
+        public string Version { get; set; }
+        public bool SkipMetadataGeneration { get; set; }
+        public AnnotationOptions Annotations { get; set; }
+        public bool ValidateSchema { get; set; }
+        public bool AttributesOnNewLines { get; set; }
+        public string EntityContainerName { get; set; }
+        public bool ShowSources { get; set; }
     }
 
     [Flags]

--- a/ApiDoctor.Publishing/CSDL/csdlwriter.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlwriter.cs
@@ -637,8 +637,7 @@ namespace ApiDoctor.Publishing.CSDL
         {
             if (annotatable.Annotation?.Count > 0)
             {
-                Annotations annotations;
-                if (schemaLevelAnnotations.TryGetValue(fullName, out annotations))
+                if (schemaLevelAnnotations.TryGetValue(fullName, out Annotations annotations))
                 {
                     foreach (var annotation in annotatable.Annotation)
                     {

--- a/ApiDoctor.Publishing/CSDL/csdlwriter.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlwriter.cs
@@ -23,8 +23,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-using System.Text.RegularExpressions;
-
 namespace ApiDoctor.Publishing.CSDL
 {
     using Validation;
@@ -35,7 +33,6 @@ namespace ApiDoctor.Publishing.CSDL
     using System.Text;
     using System.Threading.Tasks;
     using Validation.OData;
-    using Validation.Config;
     using Validation.OData.Transformation;
     using Validation.Http;
     using System.IO;
@@ -62,8 +59,7 @@ namespace ApiDoctor.Publishing.CSDL
 
             if (!string.IsNullOrEmpty(options.MergeWithMetadataPath))
             {
-                EntityFramework secondFramework =
-                    CreateEntityFrameworkFromDocs(issues, options.MergeWithMetadataPath, generateFromDocs: false);
+                EntityFramework secondFramework = CreateEntityFrameworkFromDocs(issues, options.MergeWithMetadataPath, generateFromDocs: false);
                 framework = framework.MergeWith(secondFramework);
                 outputFilenameSuffix += "-merged";
             }
@@ -76,8 +72,7 @@ namespace ApiDoctor.Publishing.CSDL
                     .Where(x => x.SchemaChanges.TransformationName == options.TransformOutput).FirstOrDefault();
                 if (null == transformations)
                 {
-                    throw new KeyNotFoundException(
-                        $"Unable to locate a transformation set named {options.TransformOutput}. Aborting.");
+                    throw new KeyNotFoundException($"Unable to locate a transformation set named {options.TransformOutput}. Aborting.");
                 }
 
                 string[] versionsToPublish = options.Version?.Split(new char[] { ',', ' ' });
@@ -107,16 +102,14 @@ namespace ApiDoctor.Publishing.CSDL
             }
             else if (options.Formats.HasFlag(MetadataFormat.SchemaOutput))
             {
-                xmlData = ODataParser.Serialize<Schema>(framework.DataServices.Schemas.First(),
-                    options.AttributesOnNewLines);
+                xmlData = ODataParser.Serialize<Schema>(framework.DataServices.Schemas.First(), options.AttributesOnNewLines);
             }
 
             // Step 3: Write the XML to disk
 
             if (!string.IsNullOrEmpty(outputFolder))
             {
-                var outputFullName =
-                    GenerateOutputFileFullName(options.SourceMetadataPath, outputFolder, outputFilenameSuffix);
+                var outputFullName = GenerateOutputFileFullName(options.SourceMetadataPath, outputFolder, outputFilenameSuffix);
                 Console.WriteLine($"Publishing metadata to {outputFullName}");
 
                 using (var writer = File.CreateText(outputFullName))
@@ -132,8 +125,7 @@ namespace ApiDoctor.Publishing.CSDL
             }
         }
 
-        private string GenerateOutputFileFullName(string templateFilename, string outputFolderPath,
-            string filenameSuffix)
+        private string GenerateOutputFileFullName(string templateFilename, string outputFolderPath, string filenameSuffix)
         {
             var outputDir = new DirectoryInfo(outputFolderPath);
             outputDir.Create();
@@ -143,8 +135,7 @@ namespace ApiDoctor.Publishing.CSDL
             string filename = null;
             if (!string.IsNullOrEmpty(templateFilename))
             {
-                filename =
-                    $"{Path.GetFileNameWithoutExtension(templateFilename)}{filenameSuffix}{Path.GetExtension(templateFilename)}";
+                filename = $"{Path.GetFileNameWithoutExtension(templateFilename)}{filenameSuffix}{Path.GetExtension(templateFilename)}";
             }
             else
             {
@@ -235,9 +226,7 @@ namespace ApiDoctor.Publishing.CSDL
                     this.ProcessRestRequestPaths(edmx, DocSet.SchemaConfig.BaseUrls, issues);
 
                     // add enums to the default schema
-                    var defaultSchema =
-                        edmx.DataServices.Schemas.FirstOrDefault(s =>
-                            s.Namespace == DocSet.SchemaConfig.DefaultNamespace);
+                    var defaultSchema = edmx.DataServices.Schemas.FirstOrDefault(s => s.Namespace == DocSet.SchemaConfig.DefaultNamespace);
                     foreach (var enumDefinition in Documents.Enums.GroupBy(e => e.TypeName))
                     {
                         var enumType = new EnumType
@@ -247,9 +236,7 @@ namespace ApiDoctor.Publishing.CSDL
                                 new EnumMember
                                 {
                                     Name = e.MemberName,
-                                    Value = e.NumericValue.HasValue
-                                        ? e.NumericValue.GetValueOrDefault().ToString()
-                                        : null
+                                    Value = e.NumericValue.HasValue ? e.NumericValue.GetValueOrDefault().ToString() : null
                                 }).ToList(),
                             IsFlags = enumDefinition.FirstOrDefault().IsFlags,
                         };
@@ -407,15 +394,13 @@ namespace ApiDoctor.Publishing.CSDL
                             foreach (var entitySet in container.EntitySets)
                             {
                                 var annotationName = prefix + "/" + entitySet.Name;
-                                AddHttpRequestsAnnotations(annotationsMap, entitySet.SourceMethods as MethodCollection,
-                                    annotationName, issues.For(annotationName));
+                                AddHttpRequestsAnnotations(annotationsMap, entitySet.SourceMethods as MethodCollection, annotationName, issues.For(annotationName));
                             }
 
                             foreach (var singleton in container.Singletons)
                             {
                                 var annotationName = prefix + "/" + singleton.Name;
-                                AddHttpRequestsAnnotations(annotationsMap, singleton.SourceMethods as MethodCollection,
-                                    annotationName, issues.For(annotationName));
+                                AddHttpRequestsAnnotations(annotationsMap, singleton.SourceMethods as MethodCollection, annotationName, issues.For(annotationName));
                             }
                         }
 
@@ -503,8 +488,7 @@ namespace ApiDoctor.Publishing.CSDL
             }
         }
 
-        private static void AddHttpRequestsAnnotations(Dictionary<string, Annotations> annotationsMap,
-            MethodCollection methods, string target, IssueLogger issues)
+        private static void AddHttpRequestsAnnotations(Dictionary<string, Annotations> annotationsMap, MethodCollection methods, string target, IssueLogger issues)
         {
             if (methods != null)
             {
@@ -514,11 +498,7 @@ namespace ApiDoctor.Publishing.CSDL
             }
         }
 
-        private static void AddRestrictionAnnotations<T>(Dictionary<string, Annotations> annotationsMap,
-            T set,
-            MethodCollection methods,
-            string target,
-            IssueLogger issues) where T : ISet
+        private static void AddRestrictionAnnotations(Dictionary<string, Annotations> annotationsMap, ISet set, MethodCollection methods, string target, IssueLogger issues)
         {
             if (methods != null)
             {
@@ -533,13 +513,9 @@ namespace ApiDoctor.Publishing.CSDL
             }
         }
 
-        private static Dictionary<string, List<IODataAnnotatable>> AddRestrictionAnnotations<T>(T set,
-            MethodCollection sourceMethod,
-            string target,
-            IssueLogger issues) where T : ISet
+        private static Dictionary<string, List<IODataAnnotatable>> AddRestrictionAnnotations(ISet set, MethodCollection sourceMethod, string target, IssueLogger issues)
         {
             var targets = new Dictionary<string, List<IODataAnnotatable>>();
-
             foreach (var method in sourceMethod)
             {
                 var url = method.RequestUriPathOnly(DocSet.SchemaConfig.BaseUrls, issues);
@@ -588,6 +564,7 @@ namespace ApiDoctor.Publishing.CSDL
                         break;
                 }
                 var key = stringBuilder.ToString();
+                
                 var exists = targets.TryGetValue(key, out var annotationsList);
                 if (exists)
                 {
@@ -601,8 +578,7 @@ namespace ApiDoctor.Publishing.CSDL
             return targets;
         }
 
-        private static PropertyValue GetNestedRestriction(MethodDefinition sourceMethod,
-            string propertyRestriction = Term.ReadByKeyRestrictionsTerm)
+        private static PropertyValue GetNestedRestriction(MethodDefinition sourceMethod, string propertyRestriction = Term.ReadByKeyRestrictionsTerm)
         {
             var propertyValue = new PropertyValue
             {
@@ -671,8 +647,7 @@ namespace ApiDoctor.Publishing.CSDL
             }
         }
 
-        private static void AddHttpRequestsAnnotations(IODataAnnotatable annotatable, MethodCollection methods,
-            IssueLogger issues)
+        private static void AddHttpRequestsAnnotations(IODataAnnotatable annotatable, MethodCollection methods, IssueLogger issues)
         {
             if (methods != null)
             {
@@ -854,8 +829,7 @@ namespace ApiDoctor.Publishing.CSDL
 
             return record;
         }
-        private static void MergeAnnotations(string fullName, IODataAnnotatable annotatable,
-            Dictionary<string, Annotations> schemaLevelAnnotations)
+        private static void MergeAnnotations(string fullName, IODataAnnotatable annotatable, Dictionary<string, Annotations> schemaLevelAnnotations)
         {
             if (annotatable.Annotation?.Count > 0)
             {
@@ -972,8 +946,7 @@ namespace ApiDoctor.Publishing.CSDL
             }
         }
 
-        private void AppendToNavigationProperty(EntityFramework edmx, ODataTargetInfo navigationProperty,
-            MethodCollection methods, IssueLogger issues)
+        private void AppendToNavigationProperty(EntityFramework edmx, ODataTargetInfo navigationProperty, MethodCollection methods, IssueLogger issues)
         {
             EntityType parentType = edmx.ResourceWithIdentifier<EntityType>(navigationProperty.QualifiedType);
 
@@ -1004,8 +977,7 @@ namespace ApiDoctor.Publishing.CSDL
         /// </summary>
         /// <param name="requestTarget"></param>
         /// <param name="methodCollection"></param>
-        private void AppendToEntityType(EntityFramework edmx, ODataTargetInfo requestTarget,
-            MethodCollection methodCollection)
+        private void AppendToEntityType(EntityFramework edmx, ODataTargetInfo requestTarget, MethodCollection methodCollection)
         {
             StringBuilder sb = new StringBuilder();
             const string seperator = ", ";

--- a/ApiDoctor.Publishing/CSDL/csdlwriter.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlwriter.cs
@@ -1190,7 +1190,7 @@ namespace ApiDoctor.Publishing.CSDL
                         var singleton = new Singleton
                         {
                             Name = name,
-                            Type = methodCollection.ResponseType.ODataResourceName(),
+                            Type = methodCollection.ResponseType?.ODataResourceName(),
                             SourceMethods = methodCollection,
                         };
 
@@ -1761,6 +1761,7 @@ namespace ApiDoctor.Publishing.CSDL
 
         private static void AddReadByKeyRestriction(IODataAnnotatable annotatable, MethodDefinition sourceMethod)
         {
+            annotatable.Annotation ??= new List<Annotation>();
             var readRestriction =
                 annotatable.Annotation.FirstOrDefault(annotation => annotation.Term == Term.ReadRestrictionTerm);
             if (readRestriction != null)
@@ -1783,6 +1784,7 @@ namespace ApiDoctor.Publishing.CSDL
         private static void AddRestrictionAnnotation(IODataAnnotatable annotatable, MethodDefinition sourceMethod,
             string restriction)
         {
+            annotatable.Annotation ??= new List<Annotation>();
             var existingAnnotation = annotatable.Annotation.FirstOrDefault(x => x.Term == restriction);
             var property = GetDescriptionPropertyValues(sourceMethod);
             var record = new Record { PropertyValues = property };

--- a/ApiDoctor.Validation.UnitTests/DocFileForTesting.cs
+++ b/ApiDoctor.Validation.UnitTests/DocFileForTesting.cs
@@ -25,6 +25,7 @@
 
 namespace ApiDoctor.Validation.UnitTests
 {
+    using Error;
     public class DocFileForTesting : DocFile
     {
         private readonly string contentsOfFile;
@@ -37,7 +38,7 @@ namespace ApiDoctor.Validation.UnitTests
             this.Parent = parent;
         }
 
-        protected override string GetContentsOfFile(string tags)
+        protected override string GetContentsOfFile(string tags, IssueLogger issues = default)
         {
             return this.contentsOfFile;
         }

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -262,7 +262,9 @@ namespace ApiDoctor.Validation
         /// Parses the file contents and removes yaml front matter from the markdown.
         /// </summary>
         /// <param name="contents">Contents.</param>
-        internal static (string YamlFrontMatter, string ProcessedContent) ParseAndRemoveYamlFrontMatter(string contents, IssueLogger issues)
+        /// <param name="issues">The issue logger to use</param>
+        /// <param name="isInclude">Whether the file contents is part of another file</param>
+        internal static (string YamlFrontMatter, string ProcessedContent) ParseAndRemoveYamlFrontMatter(string contents, IssueLogger issues, bool isInclude = false)
         {
             const string yamlFrontMatterHeader = "---";
             using var reader = new StringReader(contents);
@@ -278,7 +280,7 @@ namespace ApiDoctor.Validation
                         if (!string.IsNullOrWhiteSpace(trimmedCurrentLine) && trimmedCurrentLine != yamlFrontMatterHeader)
                         {
                             var requiredYamlHeaders = DocSet.SchemaConfig.RequiredYamlHeaders;
-                            if (requiredYamlHeaders.Any())
+                            if (requiredYamlHeaders.Any() && !isInclude)//include files don't need the headers
                             {
                                 issues.Error(ValidationErrorCode.RequiredYamlHeaderMissing, $"Missing required YAML headers: {requiredYamlHeaders.ComponentsJoinedByString(", ")}");
                             }

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * API Doctor
  * Copyright (c) Microsoft Corporation
  * All rights reserved. 
@@ -197,12 +197,13 @@ namespace ApiDoctor.Validation
             return tagProcessor.PostProcess(inputHtml, fileInfo, null);
         }
 
-        protected virtual string GetContentsOfFile(string tags)
+        protected virtual string GetContentsOfFile(string tags, IssueLogger issues = default)
         {
+            _ = issues ?? throw new ArgumentNullException(nameof(issues));
             // Preprocess file content
             FileInfo docFile = new FileInfo(this.FullPath);
             TagProcessor tagProcessor = new TagProcessor(tags, Parent.SourceFolderPath);
-            return tagProcessor.Preprocess(docFile);
+            return tagProcessor.Preprocess(docFile, issues);
         }
 
         /// <summary>
@@ -241,9 +242,14 @@ namespace ApiDoctor.Validation
         {
             try
             {
-                string fileContents = this.GetContentsOfFile(tags);
-                fileContents = this.ParseAndRemoveYamlFrontMatter(fileContents, issues);
-                return fileContents;
+                string fileContents = this.GetContentsOfFile(tags, issues);
+                var (yamlFrontMatter, processedContent) = ParseAndRemoveYamlFrontMatter(fileContents, issues);
+                // Only Parse Yaml metadata if its present.
+                if (!string.IsNullOrWhiteSpace(yamlFrontMatter))
+                {
+                    ParseYamlMetadata(yamlFrontMatter, issues);
+                }
+                return processedContent;
             }
             catch (Exception ex)
             {
@@ -256,74 +262,70 @@ namespace ApiDoctor.Validation
         /// Parses the file contents and removes yaml front matter from the markdown.
         /// </summary>
         /// <param name="contents">Contents.</param>
-        private string ParseAndRemoveYamlFrontMatter(string contents, IssueLogger issues)
+        internal static (string YamlFrontMatter, string ProcessedContent) ParseAndRemoveYamlFrontMatter(string contents, IssueLogger issues)
         {
-            const string YamlFrontMatterHeader = "---";
-            using (StringReader reader = new StringReader(contents))
+            const string yamlFrontMatterHeader = "---";
+            using var reader = new StringReader(contents);
+            var currentLine = reader.ReadLine();
+            var frontMatter = new System.Text.StringBuilder();
+            var currentState = YamlFrontMatterDetectionState.NotDetected;
+            while (currentLine != null && currentState != YamlFrontMatterDetectionState.SecondTokenFound)
             {
-                string currentLine = reader.ReadLine();
-                System.Text.StringBuilder frontMatter = new System.Text.StringBuilder();
-                YamlFrontMatterDetectionState currentState = YamlFrontMatterDetectionState.NotDetected;
-                while (currentLine != null && currentState != YamlFrontMatterDetectionState.SecondTokenFound)
+                var trimmedCurrentLine = currentLine.Trim();
+                switch (currentState)
                 {
-                    string trimmedCurrentLine = currentLine.Trim();
-                    switch (currentState)
-                    {
-                        case YamlFrontMatterDetectionState.NotDetected:
-                            if (!string.IsNullOrWhiteSpace(trimmedCurrentLine) && trimmedCurrentLine != YamlFrontMatterHeader)
+                    case YamlFrontMatterDetectionState.NotDetected:
+                        if (!string.IsNullOrWhiteSpace(trimmedCurrentLine) && trimmedCurrentLine != yamlFrontMatterHeader)
+                        {
+                            var requiredYamlHeaders = DocSet.SchemaConfig.RequiredYamlHeaders;
+                            if (requiredYamlHeaders.Any())
                             {
-                                var requiredYamlHeaders = DocSet.SchemaConfig.RequiredYamlHeaders;
-                                if (requiredYamlHeaders.Any())
-                                {
-                                    issues.Error(ValidationErrorCode.RequiredYamlHeaderMissing, $"Missing required YAML headers: {requiredYamlHeaders.ComponentsJoinedByString(", ")}");
-                                }
+                                issues.Error(ValidationErrorCode.RequiredYamlHeaderMissing, $"Missing required YAML headers: {requiredYamlHeaders.ComponentsJoinedByString(", ")}");
+                            }
 
-                                // This file doesn't have YAML front matter, so we just return the full contents of the file
-                                return contents;
-                            }
-                            else if (trimmedCurrentLine == YamlFrontMatterHeader)
-                            {
-                                currentState = YamlFrontMatterDetectionState.FirstTokenFound;
-                            }
-                            break;
-                        case YamlFrontMatterDetectionState.FirstTokenFound:
-                            if (trimmedCurrentLine == YamlFrontMatterHeader)
-                            {
-                                // Found the end of the YAML front matter, so move to the final state
-                                currentState = YamlFrontMatterDetectionState.SecondTokenFound;
-                            }
-                            else
-                            {
-                                // Store the YAML data into our header
-                                frontMatter.AppendLine(currentLine);
-                            }
-                            break;
+                            // This file doesn't have YAML front matter, so we just return the full contents of the file
+                            return (YamlFrontMatter: null, ProcessedContent: contents);
+                        }
+                        else if (trimmedCurrentLine == yamlFrontMatterHeader)
+                        {
+                            currentState = YamlFrontMatterDetectionState.FirstTokenFound;
+                        }
+                        break;
+                    case YamlFrontMatterDetectionState.FirstTokenFound:
+                        if (trimmedCurrentLine == yamlFrontMatterHeader)
+                        {
+                            // Found the end of the YAML front matter, so move to the final state
+                            currentState = YamlFrontMatterDetectionState.SecondTokenFound;
+                        }
+                        else
+                        {
+                            // Store the YAML data into our header
+                            frontMatter.AppendLine(currentLine);
+                        }
+                        break;
 
-                        case YamlFrontMatterDetectionState.SecondTokenFound:
-                            break;
-                    }
-
-                    if (currentState != YamlFrontMatterDetectionState.SecondTokenFound)
-                    {
-                        currentLine = reader.ReadLine();
-                    }
+                    case YamlFrontMatterDetectionState.SecondTokenFound:
+                        break;
                 }
 
-                if (currentState == YamlFrontMatterDetectionState.SecondTokenFound)
+                if (currentState != YamlFrontMatterDetectionState.SecondTokenFound)
                 {
-                    // Parse YAML metadata
-                    ParseYamlMetadata(frontMatter.ToString(), issues);
-                    return reader.ReadToEnd();
+                    currentLine = reader.ReadLine();
                 }
-                else
-                {
-                    // Something went wrong along the way, so we just return the full file
-                    return contents;
-                }
+            }
+
+            if (currentState == YamlFrontMatterDetectionState.SecondTokenFound)
+            {
+                return (YamlFrontMatter: frontMatter.ToString(), ProcessedContent: reader.ReadToEnd());
+            }
+            else
+            {
+                // Something went wrong along the way, so we just return the full file
+                return (YamlFrontMatter: null, ProcessedContent: contents);
             }
         }
 
-        private void ParseYamlMetadata(string yamlMetadata, IssueLogger issues)
+        internal static void ParseYamlMetadata(string yamlMetadata, IssueLogger issues)
         {
             Dictionary<string, string> dictionary = new Dictionary<string, string>();
             string[] items = yamlMetadata.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
@@ -402,7 +404,7 @@ namespace ApiDoctor.Validation
             var blockContent = GetBlockContent(block);
             if (blockContent == string.Empty)
                 return blockContent;
-            
+
             const int previewLength = 35;
 
             string contentPreview = block.Content.Length > previewLength ? block.Content.Substring(0, previewLength) : block.Content;
@@ -446,12 +448,13 @@ namespace ApiDoctor.Validation
         /// Convert blocks of text found inside the markdown file into things we know how to work
         /// with (methods, resources, examples, etc).
         /// </summary>
-        /// <param name="errors"></param>
+        /// <param name="issues"></param>
         /// <returns></returns>
         protected bool ParseMarkdownBlocks(IssueLogger issues)
         {
             string methodTitle = null;
             string methodDescription = null;
+            List<string> methodDescriptionsData = new List<string>();
 
             Block previousHeaderBlock = null;
 
@@ -471,7 +474,7 @@ namespace ApiDoctor.Validation
                 }
 
                 // Capture h1 and/or p element to be used as the title and description for items on this page
-                if (IsHeaderBlock(block))
+                if (block.BlockType == BlockType.h1)
                 {
                     methodTitle = block.Content;
                     methodDescription = null;       // Clear this because we don't want new title + old description
@@ -484,9 +487,10 @@ namespace ApiDoctor.Validation
                         issues.Warning(ValidationErrorCode.MissingHeaderBlock,
                             $"Paragraph text found before a valid header: {block.Content.Substring(0, Math.Min(block.Content.Length, 20))}...");
                     }
-                    else if (IsHeaderBlock(previousHeaderBlock))
+                    else if (previousHeaderBlock.BlockType == BlockType.h1)
                     {
-                        methodDescription = block.Content;
+                        methodDescriptionsData.Add(block.Content);
+                        methodDescription = string.Join(" ", methodDescriptionsData.Skip(1));
                         issues.Message($"Found description: {methodDescription}");
                     }
                 }
@@ -776,7 +780,7 @@ namespace ApiDoctor.Validation
 
             var elementsFoundInDocument = elements as IList<object> ?? elements.ToList();
             var foundMethods = elementsFoundInDocument.OfType<MethodDefinition>().ToList();
-            var foundTables = elementsFoundInDocument.OfType<TableDefinition>().ToList();            
+            var foundTables = elementsFoundInDocument.OfType<TableDefinition>().ToList();
             var foundResources = elementsFoundInDocument.OfType<ResourceDefinition>()
                 .Select(c => { c.Namespace = this.Namespace; return c; }).ToList();
             var foundEnums = foundTables.Where(t => t.Type == TableBlockType.EnumerationValues)
@@ -795,7 +799,7 @@ namespace ApiDoctor.Validation
             string inferredNamespace = null;
             if (foundResource != null)
             {
-                if (foundResource.Name.Contains('.')) { 
+                if (foundResource.Name.Contains('.')) {
                     inferredNamespace = foundResource.Name.Substring(0, foundResource.Name.LastIndexOf('.'));
                 }
                 if (this.Annotation?.Namespace != null && this.Annotation.Namespace != inferredNamespace)
@@ -1053,7 +1057,7 @@ namespace ApiDoctor.Validation
                 {
                     issues.Error(ValidationErrorCode.HttpParserError, $"Exception while parsing HTTP request", ex);
                 }
-                
+
                 if (distinctMethodNames == 1)
                 {
                     foreach (var method in foundMethods)

--- a/ApiDoctor.Validation/Error/validationerror.cs
+++ b/ApiDoctor.Validation/Error/validationerror.cs
@@ -127,6 +127,7 @@ namespace ApiDoctor.Validation.Error
         NamespaceMismatch,
 
         AmbiguousExample,
+        HttpMethodOutOfRange
     }
 
     public class ValidationError

--- a/ApiDoctor.Validation/MethodDefinition.cs
+++ b/ApiDoctor.Validation/MethodDefinition.cs
@@ -104,6 +104,7 @@ namespace ApiDoctor.Validation
                         method.RequestBodyParameters.AddRange(requestBodyResource.Parameters);
                     }
                 }
+                method.HttpRequest = requestExample;
             }
             catch (Exception ex)
             {
@@ -128,6 +129,11 @@ namespace ApiDoctor.Validation
         public string Request {get; private set;}
 
         /// <summary>
+        /// The parsed Request data from the documentation. 
+        /// </summary>
+        public HttpRequest HttpRequest { get; private set; }
+
+        /// <summary>
         /// Properties about the Request populated from the documentation
         /// </summary>
         public CodeBlockAnnotation RequestMetadata { get; private set; }
@@ -148,7 +154,7 @@ namespace ApiDoctor.Validation
         /// </summary>
         /// <value>The source file.</value>
         public DocFile SourceFile {get; private set;}
-        
+
         /// <summary>
         /// The raw HTTP response from the actual service
         /// </summary>
@@ -366,7 +372,7 @@ namespace ApiDoctor.Validation
                 builder = new UriBuilder(request.Url);
                 path = builder.Path;
             }
-            
+
             string[] parts = path.Split('/');
             if (parts.Length > 0)
             {
@@ -415,7 +421,7 @@ namespace ApiDoctor.Validation
                     request.Headers.Add(split[0], split[1]);
                 }
             }
-        }    
+        }
 
         internal static void AddAccessTokenToRequest(AuthenicationCredentials credentials, HttpRequest request)
         {
@@ -471,7 +477,7 @@ namespace ApiDoctor.Validation
 
                 if (param.Value == null)
                     request.Headers.Remove(headerName);
-                else 
+                else
                     request.Headers[headerName] = param.Value;
             }
         }
@@ -587,7 +593,7 @@ namespace ApiDoctor.Validation
         private void VerifyResponseBody(HttpResponse actualResponse, HttpResponse expectedResponse, IssueLogger issues, ValidationOptions options = null)
         {
             if (string.IsNullOrEmpty(actualResponse.Body) &&
-                ((expectedResponse != null && !string.IsNullOrEmpty(expectedResponse.Body)) || 
+                ((expectedResponse != null && !string.IsNullOrEmpty(expectedResponse.Body)) ||
                  (this.ExpectedResponseMetadata != null && this.ExpectedResponseMetadata.ResourceType != null)))
             {
                 issues.Error(ValidationErrorCode.HttpBodyExpected, "Body missing from response (expected response includes a body or a response type was provided).");

--- a/ApiDoctor.Validation/OData/EntitySet.cs
+++ b/ApiDoctor.Validation/OData/EntitySet.cs
@@ -25,16 +25,14 @@
 
 namespace ApiDoctor.Validation.OData
 {
-    using Newtonsoft.Json;
     using System.Collections.Generic;
     using System.Xml.Serialization;
     using Transformation;
-    using System;
     using Utility;
 
     [XmlRoot("EntitySet", Namespace = ODataParser.EdmNamespace)]
     [Mergable(CollectionIdentifier = "Name")]
-    public class EntitySet : XmlBackedTransformableObject, IODataAnnotatable
+    public class EntitySet : XmlBackedTransformableObject, IODataAnnotatable, ISet
     {
         public EntitySet()
         {

--- a/ApiDoctor.Validation/OData/ISet.cs
+++ b/ApiDoctor.Validation/OData/ISet.cs
@@ -27,11 +27,11 @@ namespace ApiDoctor.Validation.OData
 {
     using System.Collections.Generic;
 
-    /// <summary>
-    /// Interface for elements that can be annotated;
-    /// </summary>
-    public interface IODataAnnotatable : IODataNamedElement
+    public interface ISet
     {
+        string Name { get; set; }
         List<Annotation> Annotation { get; set; }
+        List<NavigationPropertyBinding> NavigationPropertyBinding { get; set; }
+        object SourceMethods { get; set; }
     }
 }

--- a/ApiDoctor.Validation/OData/Singleton.cs
+++ b/ApiDoctor.Validation/OData/Singleton.cs
@@ -33,7 +33,7 @@ namespace ApiDoctor.Validation.OData
 
     [XmlRoot("Singleton", Namespace = ODataParser.EdmNamespace)]
     [Mergable(CollectionIdentifier = "Name")]
-    public class Singleton : XmlBackedTransformableObject, IODataAnnotatable
+    public class Singleton : XmlBackedTransformableObject, IODataAnnotatable, ISet
     {
         public Singleton()
         {

--- a/ApiDoctor.Validation/OData/Term.cs
+++ b/ApiDoctor.Validation/OData/Term.cs
@@ -66,6 +66,11 @@ namespace ApiDoctor.Validation.OData
         public const string SearchRestrictionsTerm = "Org.OData.Capabilities.V1.SearchRestrictions";
         public const string ChangeTrackingTerm = "Org.OData.Capabilities.V1.ChangeTracking";
         public const string NavigationRestrictionsTerm = "Org.OData.Capabilities.V1.NavigationRestrictions";
+        public const string ReadRestrictionTerm = "Org.OData.Capabilities.V1.ReadRestrictions";
+        public const string ReadByKeyRestrictionsTerm = "ReadByKeyRestrictions";
+        public const string InsertRestrictionsTerm = "Org.OData.Capabilities.V1.InsertRestrictions";
+        public const string UpdateRestrictions = "Org.OData.Capabilities.V1.UpdateRestrictions";
+        public const string DeleteRestrictions = "Org.OData.Capabilities.V1.DeleteRestrictions";
 
 
         [XmlIgnore, MergePolicy(MergePolicy.Ignore)]

--- a/ApiDoctor.Validation/Params/CSharpEval.cs
+++ b/ApiDoctor.Validation/Params/CSharpEval.cs
@@ -31,6 +31,7 @@ namespace ApiDoctor.Validation.Params
     using Microsoft.CSharp;
     using System.CodeDom.Compiler;
     using System.Collections.Generic;
+    using System.Runtime.Versioning;
     internal static class CSharpEval
     {
         public static string Evaluate(string code, IReadOnlyDictionary<string, string> values)
@@ -78,6 +79,7 @@ namespace ApiDoctor.Validation.Params
             }
         }
 
+        [UnsupportedOSPlatform("ios")]
         private static Assembly GenerateAssembly(string code)
         {
             CSharpCodeProvider provider = new CSharpCodeProvider();

--- a/ApiDoctor.Validation/Params/CSharpEval.cs
+++ b/ApiDoctor.Validation/Params/CSharpEval.cs
@@ -34,6 +34,7 @@ namespace ApiDoctor.Validation.Params
     using System.Runtime.Versioning;
     internal static class CSharpEval
     {
+        [UnsupportedOSPlatform("ios")]
         public static string Evaluate(string code, IReadOnlyDictionary<string, string> values)
         {
             if (!code.EndsWith(";"))

--- a/ApiDoctor.Validation/Params/CSharpEval.cs
+++ b/ApiDoctor.Validation/Params/CSharpEval.cs
@@ -31,10 +31,9 @@ namespace ApiDoctor.Validation.Params
     using Microsoft.CSharp;
     using System.CodeDom.Compiler;
     using System.Collections.Generic;
-    using System.Runtime.Versioning;
+
     internal static class CSharpEval
     {
-        [UnsupportedOSPlatform("ios")]
         public static string Evaluate(string code, IReadOnlyDictionary<string, string> values)
         {
             if (!code.EndsWith(";"))
@@ -80,7 +79,6 @@ namespace ApiDoctor.Validation.Params
             }
         }
 
-        [UnsupportedOSPlatform("ios")]
         private static Assembly GenerateAssembly(string code)
         {
             CSharpCodeProvider provider = new CSharpCodeProvider();

--- a/ApiDoctor.Validation/SupplementalFile.cs
+++ b/ApiDoctor.Validation/SupplementalFile.cs
@@ -46,7 +46,7 @@ namespace ApiDoctor.Validation
         {
         }
 
-        protected override string GetContentsOfFile(string tags)
+        protected override string GetContentsOfFile(string tags, IssueLogger issues=default)
         {
             return File.ReadAllText(Path.Combine(this.FullPath));
         }
@@ -55,7 +55,7 @@ namespace ApiDoctor.Validation
         {
             try
             {
-                var content = this.GetContentsOfFile(tags);
+                var content = this.GetContentsOfFile(tags, issues);
                 var xd = XDocument.Parse(content);
                 this.MarkdownLinks = AllAttribues(xd.Root).
                     Where(a => LikelyUrlAttributes.Contains(a.Name.ToString()) && !string.IsNullOrEmpty(a.Value)).

--- a/ApiDoctor.Validation/Tags/TagProcessor.cs
+++ b/ApiDoctor.Validation/Tags/TagProcessor.cs
@@ -390,7 +390,6 @@ namespace ApiDoctor.Validation.Tags
         /// <returns></returns>
         private static bool IsDocFxVideoLine(string text)
         {
-            var upperNextLine = text.ToUpper();
             if (text.ToUpper().Contains("VIDEO"))
             {
                 return VideoFormat.IsMatch(text);
@@ -434,7 +433,7 @@ namespace ApiDoctor.Validation.Tags
             {
                 var relativePath = Path.ChangeExtension(m.Groups[1].Value, "md");
 
-                var fullPathToIncludeFile = string.Empty;
+                string fullPathToIncludeFile;
 
                 if (Path.IsPathRooted(relativePath))
                 {

--- a/ApiDoctor.Validation/Tags/TagProcessor.cs
+++ b/ApiDoctor.Validation/Tags/TagProcessor.cs
@@ -183,7 +183,7 @@ namespace ApiDoctor.Validation.Tags
 
                             // Include Files can have Yaml Front Matter as well.
                             var includeContent = Preprocess(includeFile, issues);
-                            var (_, processedContent) = DocFile.ParseAndRemoveYamlFrontMatter(includeContent, issues);
+                            var (_, processedContent) = DocFile.ParseAndRemoveYamlFrontMatter(includeContent, issues,true);
                             writer.WriteLine(processedContent);
                         }
                         else

--- a/ApiDoctor.Validation/Tags/TagProcessor.cs
+++ b/ApiDoctor.Validation/Tags/TagProcessor.cs
@@ -70,8 +70,9 @@ namespace ApiDoctor.Validation.Tags
         /// Loads Markdown content from a file and removes unwanted content in preparation for passing to MarkdownDeep converter.
         /// </summary>
         /// <param name="sourceFile">The file containing the Markdown contents to preprocess.</param>
+        /// <param name="issues"></param>
         /// <returns>The preprocessed contents of the file.</returns>
-        public string Preprocess(FileInfo sourceFile)
+        public string Preprocess(FileInfo sourceFile, IssueLogger issues)
         {
             using (var writer = new StringWriter())
             using (var reader = new StreamReader(sourceFile.OpenRead()))
@@ -180,9 +181,10 @@ namespace ApiDoctor.Validation.Tags
                                 continue;
                             }
 
-                            var includeContent = Preprocess(includeFile);
-
-                            writer.WriteLine(includeContent);
+                            // Include Files can have Yaml Front Matter as well.
+                            var includeContent = Preprocess(includeFile, issues);
+                            var (_, processedContent) = DocFile.ParseAndRemoveYamlFrontMatter(includeContent, issues);
+                            writer.WriteLine(processedContent);
                         }
                         else
                         {


### PR DESCRIPTION
***Blocking Bugs***
Initial implementation blocked by a bug where APiDoctor mishandles YAML Front Matter, thereby misunderstanding the whole document model and breaking downstream csdl handling logic. 

***Features***
Extract Operation titles and descriptions and inject them into generated csdl as `*Restrictions` (Read, ReadByKey).
![solution](https://user-images.githubusercontent.com/1641829/161852734-84bb20fd-471d-417a-bd51-47be9a6a3124.jpg)
For  the example above:-

- Extract corresponding page title as `Description`
- Extract corresponding page first paragraph as `LongDescription`

These injected `*Restrictions` will be extracted by [OpenAPI.NET.Odata](https://github.com/microsoft/OpenAPI.NET.OData/pull/206) and inserted into generated OpenAPI files as summaries and descriptions.
<img width="853" alt="image" src="https://user-images.githubusercontent.com/1641829/161854067-da641d66-6973-48bd-b49e-68e6a551de18.png">


These summaries and descriptions will then flow into the Microsoft Graph PowerShell SDK Docs which extract the summaries and descriptions and insert them into the generated docs. 


Related to https://github.com/microsoft/OpenAPI.NET.OData/pull/206
Related to https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/876