### PR TITLE
Update JsonReader and JsonSerializer MaxDepth

### DIFF
--- a/ApiDoctor.Validation/Json/JsonSchema.cs
+++ b/ApiDoctor.Validation/Json/JsonSchema.cs
@@ -27,6 +27,7 @@ namespace ApiDoctor.Validation.Json
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
     using ApiDoctor.Validation.Error;
@@ -122,7 +123,7 @@ namespace ApiDoctor.Validation.Json
                 if (string.IsNullOrWhiteSpace(jsonInput.JsonData))
                     throw new Exception("Expected json string was empty or whitespace only.");
 
-                var settings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None, NullValueHandling = NullValueHandling.Include, DefaultValueHandling = DefaultValueHandling.Include };
+                var settings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None, NullValueHandling = NullValueHandling.Include, DefaultValueHandling = DefaultValueHandling.Include, TypeNameHandling = TypeNameHandling.All, MaxDepth = 256 };
                 obj = (JContainer)JsonConvert.DeserializeObject(jsonInput.JsonData, settings);
             }
             catch (Exception ex)

--- a/ApiDoctor.Validation/Json/JsonSchema.cs
+++ b/ApiDoctor.Validation/Json/JsonSchema.cs
@@ -27,7 +27,6 @@ namespace ApiDoctor.Validation.Json
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
     using ApiDoctor.Validation.Error;

--- a/ApiDoctor.Validation/ResourceDefinition.cs
+++ b/ApiDoctor.Validation/ResourceDefinition.cs
@@ -27,6 +27,7 @@ namespace ApiDoctor.Validation
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using ApiDoctor.Validation.Error;
@@ -178,7 +179,9 @@ namespace ApiDoctor.Validation
         {
             try
             {
-                var inputObject = JsonConvert.DeserializeObject(this.OriginalExampleText);
+                var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All, MaxDepth = 256 };
+                var jsonSerializer = JsonSerializer.Create(settings);
+                var inputObject = JsonConvert.DeserializeObject<JObject>(this.OriginalExampleText, settings).ToObject(typeof(object), jsonSerializer);
 
                 JObject parsedObject = this.SourceJObject = inputObject as JObject;
                 if (parsedObject == null)

--- a/ApiDoctor.Validation/ResourceDefinition.cs
+++ b/ApiDoctor.Validation/ResourceDefinition.cs
@@ -27,7 +27,6 @@ namespace ApiDoctor.Validation
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using ApiDoctor.Validation.Error;


### PR DESCRIPTION
Newtonsoft.Json 13.0.1, changed the default MaxDepth for JsonReader to 64, and it caused a breaking change.
A legacy API surprisingly had one resource that's over the default limit. (I'm following up to clean it as well)