### PR TITLE
Fix CSDL publishing

### DIFF
--- a/ApiDoctor.Publishing/CSDL/csdlwriter.cs
+++ b/ApiDoctor.Publishing/CSDL/csdlwriter.cs
@@ -1249,6 +1249,12 @@ namespace ApiDoctor.Publishing.CSDL
                         continue;
                     }
 
+                    if (m.SourceFile.DocumentPageType != DocFile.PageType.ApiPageType)
+                    {
+                        // Ignore if not ApiPageType
+                        continue;
+                    }
+
                     var path = m.RequestUriPathOnly(baseUrlsToRemove, issues);
                     if (!path.StartsWith("/"))
                     {
@@ -1753,8 +1759,8 @@ namespace ApiDoctor.Publishing.CSDL
         {
             var descriptionPropertyValues = new List<PropertyValue>
             {
-                new() {Property = "Description", String = sourceMethod.Title},
-                new() {Property = "LongDescription", String = sourceMethod.Description.ToStringClean()}
+                new() { Property = "Description", String = sourceMethod.Title.ToStringClean() },
+                new() { Property = "LongDescription", String = sourceMethod.Description.ToStringClean() }
             };
             return descriptionPropertyValues;
         }

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -73,7 +73,7 @@ namespace ApiDoctor.Validation
         /// Contains information on the headers and content blocks found in this document.
         /// </summary>
         public List<string> ContentOutline { get; set; }
-        
+
         public PageType DocumentPageType { get; protected set; } = PageType.Unknown;
 
         public ResourceDefinition[] Resources
@@ -523,7 +523,7 @@ namespace ApiDoctor.Validation
                     else if (previousHeaderBlock.BlockType == BlockType.h1)
                     {
                         methodDescriptionsData.Add(block.Content);
-                        methodDescription = string.Join(" ", methodDescriptionsData.Skip(1));
+                        methodDescription = string.Join(" ", methodDescriptionsData.Skip(1)).RemoveMarkdownLinksFromText();
                         issues.Message($"Found description: {methodDescription}");
                     }
                 }
@@ -832,7 +832,8 @@ namespace ApiDoctor.Validation
             string inferredNamespace = null;
             if (foundResource != null)
             {
-                if (foundResource.Name.Contains('.')) {
+                if (foundResource.Name.Contains('.'))
+                {
                     inferredNamespace = foundResource.Name.Substring(0, foundResource.Name.LastIndexOf('.'));
                 }
                 if (this.Annotation?.Namespace != null && this.Annotation.Namespace != inferredNamespace)
@@ -865,10 +866,10 @@ namespace ApiDoctor.Validation
             // if we thought it was a table of type EnumerationValues, it probably holds enum values. 
             // throw error if member name is null which could mean a wrong column name
             foreach (var enumType in foundEnums.Where(e => string.IsNullOrEmpty(e.MemberName) && !string.IsNullOrEmpty(e.TypeName))
-                .Select(x => new { x.TypeName, x.Namespace}).Distinct())
+                .Select(x => new { x.TypeName, x.Namespace }).Distinct())
             {
                 var possibleHeaderNames = this.Parent?.TableParserConfig?.TableDefinitions.Rules
-                    .Where(r => r.Type == "EnumerationDefinition").SelectMany(r => r.ColumnNames["memberName"]) .ToList();
+                    .Where(r => r.Type == "EnumerationDefinition").SelectMany(r => r.ColumnNames["memberName"]).ToList();
 
                 issues.Error(ValidationErrorCode.ParameterParserError,
                     $"Failed to parse enumeration values for type {enumType.Namespace}.{enumType.TypeName}. " +

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -73,6 +73,8 @@ namespace ApiDoctor.Validation
         /// Contains information on the headers and content blocks found in this document.
         /// </summary>
         public List<string> ContentOutline { get; set; }
+        
+        public PageType DocumentPageType { get; protected set; } = PageType.Unknown;
 
         public ResourceDefinition[] Resources
         {
@@ -248,6 +250,7 @@ namespace ApiDoctor.Validation
                 if (!string.IsNullOrWhiteSpace(yamlFrontMatter))
                 {
                     ParseYamlMetadata(yamlFrontMatter, issues);
+                    SetDocumentTypeFromYamlMetadata(yamlFrontMatter);
                 }
                 return processedContent;
             }
@@ -368,11 +371,39 @@ namespace ApiDoctor.Validation
             }
         }
 
+        /// <summary>
+        /// Get document type from YAML front matter
+        /// </summary>
+        /// <returns></returns>
+        private void SetDocumentTypeFromYamlMetadata(string yamlMetadata)
+        {
+            PageType pageType = PageType.Unknown;
+            string[] items = yamlMetadata.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string item in items)
+            {
+                string[] keyValue = item.Split(':');
+                if (keyValue.Length == 2 && keyValue[0].Trim() == "doc_type")
+                {
+                    Enum.TryParse(keyValue[1].Replace("\"", string.Empty), true, out pageType);
+                }
+            }
+            this.DocumentPageType = pageType;
+        }
+
         private enum YamlFrontMatterDetectionState
         {
             NotDetected,
             FirstTokenFound,
             SecondTokenFound
+        }
+
+        public enum PageType
+        {
+            Unknown,
+            ResourcePageType,
+            ApiPageType,
+            ConceptualPageType,
+            EnumPageType
         }
 
         private static bool IsHeaderBlock(Block block, int maxDepth = 2)

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -385,6 +385,7 @@ namespace ApiDoctor.Validation
                 if (keyValue.Length == 2 && keyValue[0].Trim() == "doc_type")
                 {
                     Enum.TryParse(keyValue[1].Replace("\"", string.Empty), true, out pageType);
+                    break; //no need to keep processing as we've found the doctype tag
                 }
             }
             this.DocumentPageType = pageType;

--- a/ApiDoctor.Validation/ExtensionMethods.cs
+++ b/ApiDoctor.Validation/ExtensionMethods.cs
@@ -45,7 +45,8 @@ namespace ApiDoctor.Validation
         private const char fancyRightQuote = (char)0x201d;
         private const char singleQuote = '\'';
 
-        private static readonly Regex likelyBase64Regex = new Regex("^[a-fA-F0-9+=/]+$", RegexOptions.Compiled);
+        private static readonly Regex likelyBase64Regex = new ("^[a-fA-F0-9+=/]+$", RegexOptions.Compiled);
+        private static readonly Regex markdownLinkRegex = new (@"\[(.*?)\]((\(.*?\))|(\s*:\s*\w+))", RegexOptions.Compiled);
 
 
         private static readonly string[] Iso8601Formats =
@@ -105,6 +106,7 @@ namespace ApiDoctor.Validation
             }
 
             return value.ToString().
+                RemoveMarkdownLinksFromText().
                 Replace(fancyLeftQuote, singleQuote).
                 Replace(fancyRightQuote, singleQuote).
                 Replace('"', singleQuote).
@@ -210,6 +212,11 @@ namespace ApiDoctor.Validation
 
             value = null;
             return false;
+        }
+
+        public static string RemoveMarkdownLinksFromText(this string text)
+        {
+            return Regex.Replace(text, markdownLinkRegex.ToString(), "$1");
         }
 
         public static T PropertyValue<T>(this JContainer container, string propertyName, T defaultValue) where T : class


### PR DESCRIPTION
This is to remove markdown links from description annotations.

Some methods had wrong descriptions because the description was being fetched from methods in conceptual pages but what we are interested in is descriptions in API pages. 