### PR TITLE
Add tabs for missing snippets

### DIFF
--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2081,7 +2081,7 @@ namespace ApiDoctor.ConsoleApp
                 }
 
                 // just so that we have the correct casing displayed as tab names in docs e.g. PowerShell and not powershell
-                languages = languageOptions.Where(x => languages.Contains(x, StringComparer.OrdinalIgnoreCase)).ToHashSet();
+                languages = languageOptions.Where(x => languages.Contains(x)).ToHashSet();
 
                 snippetsLanguageSetBySourceFile.Add(docFile.DisplayName, languages);
             }

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2056,7 +2056,7 @@ namespace ApiDoctor.ConsoleApp
             var snippetTempFiles = Directory.EnumerateFiles(snippetsPath);
             foreach (DocFile docFile in docFiles)
             {
-                var languages = new HashSet<string>();
+                var languages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 foreach (var request in docFile.Requests)
                 {
                     // no need to continue if we already have the full list of languages

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -87,7 +87,7 @@ namespace ApiDoctor.ConsoleApp
                         {
                             IgnoreErrors = options.IgnoreErrors;
 #if DEBUG
-                    if (options.AttachDebugger == 1)
+                            if (options.AttachDebugger == 1)
                             {
                                 Debugger.Launch();
                             }
@@ -1932,9 +1932,9 @@ namespace ApiDoctor.ConsoleApp
                     "--SnippetsPath", snippetsPath, "--Languages", options.Languages, "--CustomMetadataPath", options.CustomMetadataPath); // args
             }
 
-            var docFiles = methods.Select(method => method.SourceFile).Distinct();
+            var docFiles = methods.Select(method => method.SourceFile).DistinctBy(x => x.DisplayName);
             var snippetsLanguageSetBySourceFile = GetSnippetsLanguageSetForDocSet(docFiles, languageOptions, snippetsPath);
-            
+
             foreach (var method in methods)
             {
                 string snippetPrefix;
@@ -2059,10 +2059,6 @@ namespace ApiDoctor.ConsoleApp
                 var languages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 foreach (var request in docFile.Requests)
                 {
-                    // no need to continue if we already have the full list of languages
-                    if (languages.Count == languageOptions.Length)
-                        break;
-
                     string snippetPrefix;
                     try { snippetPrefix = GetSnippetPrefix(request); } catch (ArgumentException) { continue; }
 

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -1950,7 +1950,7 @@ namespace ApiDoctor.ConsoleApp
 
                 if (!snippetsLanguageSetBySourceFile.TryGetValue($"{method.SourceFile.DisplayName}/{method.Identifier}", out var languagesToIncludeForMethod))
                 {
-                    languagesToIncludeForMethod = snippetsLanguageSetBySourceFile[method.SourceFile.DisplayName];
+                    snippetsLanguageSetBySourceFile.TryGetValue(method.SourceFile.DisplayName, out languagesToIncludeForMethod);
                 }
 
                 // Generate snippets section for method to inject to document
@@ -1966,7 +1966,7 @@ namespace ApiDoctor.ConsoleApp
 
         private static string GenerateSnippetsTabSectionForMethod(MethodDefinition method, HashSet<string> languages, string snippetsPath, string snippetPrefix)
         {
-            if (!languages.Any())
+            if (languages == null || !languages.Any())
                 return string.Empty;
 
             var methodString = Regex.Replace(method.Identifier, @"[# .()\\/]", "").Replace("_", "-").ToLower(); // cleanup the method name
@@ -2008,8 +2008,8 @@ namespace ApiDoctor.ConsoleApp
                     FancyConsole.WriteLine(FancyConsole.ConsoleSuccessColor, $"Writing snippet to {snippetMarkdownFilePath}");
                     File.WriteAllText(snippetMarkdownFilePath, snippetFileContents); // write snippet to file
                 }
-
             }
+
             if (snippetsTabSectionForMethod.Length > 0)
                 snippetsTabSectionForMethod.Append("---\r\n"); // append end of tab section
 

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2050,7 +2050,7 @@ namespace ApiDoctor.ConsoleApp
             return codeSnippet;
         }
 
-        private static Dictionary<string, HashSet<string>> GetSnippetsLanguageSetForDocSet(DocFile[] docFiles, string[] languageOptions, string snippetsPath)
+        private static Dictionary<string, HashSet<string>> GetSnippetsLanguageSetForDocSet(IEnumerable<DocFile> docFiles, string[] languageOptions, string snippetsPath)
         {
             var snippetsLanguageSetBySourceFile = new Dictionary<string, HashSet<string>>();
             var snippetTempFiles = Directory.EnumerateFiles(snippetsPath);

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -1932,7 +1932,8 @@ namespace ApiDoctor.ConsoleApp
                     "--SnippetsPath", snippetsPath, "--Languages", options.Languages, "--CustomMetadataPath", options.CustomMetadataPath); // args
             }
 
-            var snippetsLanguageSetBySourceFile = GetSnippetsLanguageSetForDocSet(docset.Files, languageOptions, snippetsPath);
+            var docFiles = methods.Select(method => method.SourceFile).Distinct();
+            var snippetsLanguageSetBySourceFile = GetSnippetsLanguageSetForDocSet(docFiles, languageOptions, snippetsPath);
             
             foreach (var method in methods)
             {

--- a/ApiDoctor.Validation/ExtensionMethods.cs
+++ b/ApiDoctor.Validation/ExtensionMethods.cs
@@ -174,6 +174,13 @@ namespace ApiDoctor.Validation
             }
         }
 
+        public static IEnumerable<T> Splice<T>(this IEnumerable<T> list, int start, int count)
+        {
+            var listWithDeletedElements = list.ToList();
+            listWithDeletedElements.RemoveRange(start, count);
+            return listWithDeletedElements;
+        }
+
         public static void IntersectInPlace<T>(this IList<T> source, IList<T> otherSet)
         {
             var existingList = source.ToArray();

--- a/ApiDoctor.Validation/ExtensionMethods.cs
+++ b/ApiDoctor.Validation/ExtensionMethods.cs
@@ -191,6 +191,18 @@ namespace ApiDoctor.Validation
             }
         }
 
+        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            HashSet<TKey> seenKeys = new HashSet<TKey>();
+            foreach (TSource element in source)
+            {
+                if (seenKeys.Add(keySelector(element)))
+                {
+                    yield return element;
+                }
+            }
+        }
+
         public static bool TryGetPropertyValue<T>(this JContainer container, string propertyName, out T value ) where T : class
         {
             JProperty prop;


### PR DESCRIPTION
Updates in this PR:
- Get snippets language set for document
- Ensure all methods in the document have tabs for all languages in the set
- Methods that do not have a snippet for a particular language have the information `Snippet not available` within the tab
- Removes HTTP tab if there's no snippets available in other languages
- Only adds missing tabs if method has at least one code snippet in a programming language


Docs PR with generated snippets with these changes: https://github.com/microsoftgraph/microsoft-graph-docs/pull/17711

Docs [example](https://review.docs.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0&branch=pr-en-us-17711&tabs=java#example-7-use-search-to-get-users-with-display-names-that-contain-the-letters-wa-or-the-letters-ad-including-a-count-of-returned-objects) where missing tabs have been added.
