### PR TITLE
Fix for setting IsComposable to true

### DIFF
--- a/ApiDoctor.Validation/OData/IODataNavigable.cs
+++ b/ApiDoctor.Validation/OData/IODataNavigable.cs
@@ -113,7 +113,7 @@ namespace ApiDoctor.Validation.OData
                 foreach (var m in matches)
                 {
                     // if its the last segment, it may not really be composable. So default to what already is already there.
-                    m.IsComposable = !isLastSegment || m.IsComposable;
+                    m.IsComposable |= !isLastSegment;
                 }
 
                 var match = matches.First().ReturnType.Type;

--- a/ApiDoctor.Validation/OData/IODataNavigable.cs
+++ b/ApiDoctor.Validation/OData/IODataNavigable.cs
@@ -112,7 +112,8 @@ namespace ApiDoctor.Validation.OData
             {
                 foreach (var m in matches)
                 {
-                    m.IsComposable = true;
+                    // if its the last segment, it may not really be composable. So default to what already is already there.
+                    m.IsComposable = !isLastSegment || m.IsComposable;
                 }
 
                 var match = matches.First().ReturnType.Type;


### PR DESCRIPTION
This PR addresses a bug where the `IODataNavigable.cs` would indescriminately overrride the `IsComposable` property for functions to lead to incorrect transformed metadata.

This PR applies a change to apply this condition if the Function exists in a part of the URL that is not the last segment meaning it would have to be composable for the URL to continue being built.