### PR TITLE
- adds a new command line param temp-output-path

### DIFF
--- a/ApiDoctor.Console/CommandLineOptions.cs
+++ b/ApiDoctor.Console/CommandLineOptions.cs
@@ -611,6 +611,9 @@ namespace ApiDoctor.ConsoleApp
 
         [Option("custom-metadata-path", HelpText = "Path to custom metadata that snippet generation can consume", Required = false)]
         public string CustomMetadataPath { get; set; }
+
+        [Option("temp-output-path", HelpText = "Temporary path to output the generated snippets for analysis", Required = false)]
+        public string TempOutputPath { get; set; }
     }
 
     [Verb(CommandLineOptions.VerbDeduplicateExampleNames, HelpText = "Reports duplicate names in examples and attempts to deduplicate them")]

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2106,7 +2106,7 @@ namespace ApiDoctor.ConsoleApp
 
                     var expectedFileName = $"{Path.Combine(snippetsPath, snippetPrefix)}---";
                     var snippetLanguagesForMethod = snippetTempFiles
-                        .Where(x => !x.EndsWith("-error"))
+                        .Where(x => !x.EndsWith("-error", StringComparison.OrdinalIgnoreCase))
                         .Where(x => x.StartsWith(expectedFileName))
                         .Select(x => x.Substring(expectedFileName.Length))
                         .ToHashSet();

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -1959,8 +1959,9 @@ namespace ApiDoctor.ConsoleApp
 
             FancyConsole.WriteLine(FancyConsole.ConsoleSuccessColor, "Generating snippets from Snippets API..");
 
-            var guid = Guid.NewGuid().ToString();
-            var snippetsPath = Path.Combine(Path.GetTempPath(), guid);
+            var snippetsPath = string.IsNullOrEmpty(options.TempOutputPath) ?
+                Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()) :
+                options.TempOutputPath;
             Directory.CreateDirectory(snippetsPath);
 
             WriteHttpSnippetsIntoFile(snippetsPath, methods, issues);
@@ -2001,9 +2002,6 @@ namespace ApiDoctor.ConsoleApp
                 var codeSnippetsText = GenerateSnippetsTabSectionForMethod(method, languagesToIncludeForMethod, snippetsPath, snippetPrefix);
                 InjectSnippetsIntoFile(method, codeSnippetsText);
             }
-
-            // clean up
-            Directory.Delete(snippetsPath, true /* recursive */);
 
             return true;
         }
@@ -2108,6 +2106,7 @@ namespace ApiDoctor.ConsoleApp
 
                     var expectedFileName = $"{Path.Combine(snippetsPath, snippetPrefix)}---";
                     var snippetLanguagesForMethod = snippetTempFiles
+                        .Where(x => !x.EndsWith("-error"))
                         .Where(x => x.StartsWith(expectedFileName))
                         .Select(x => x.Substring(expectedFileName.Length))
                         .ToHashSet();
@@ -2314,6 +2313,7 @@ namespace ApiDoctor.ConsoleApp
         /// <param name="issues">logging</param>
         private static void WriteHttpSnippetsIntoFile(string tempDir, MethodDefinition[] methods, IssueLogger issues)
         {
+            var duplicates = new Dictionary<string, (string OriginalSourceFile, string OriginalIdentifier, int Count)>();
             foreach (var method in methods)
             {
                 HttpRequest request;
@@ -2335,9 +2335,27 @@ namespace ApiDoctor.ConsoleApp
 
                 var fileName = snippetPrefix + "-httpSnippet";
                 var fileFullPath = Path.Combine(tempDir, fileName);
-                FancyConsole.WriteLine(FancyConsole.ConsoleSuccessColor, $"Writing {fileFullPath}");
 
-                File.WriteAllText(fileFullPath, ReplaceLFbyCRLF(request.FullHttpText(true)));
+                // if there is a duplicate in http snippet naming, write error message into a file with -duplicate<count> suffix
+                if (duplicates.ContainsKey(fileName))
+                {
+                    (var originalSourceFile, var originalIdentifier, var count) = duplicates[fileName];
+                    duplicates[fileName] = (originalSourceFile, originalIdentifier, count + 1);   
+                    var errorMessage = "OriginalFile: " + originalSourceFile + Environment.NewLine
+                                    + "OriginalIdentifier: " + originalIdentifier + Environment.NewLine
+                                    + "DuplicateFile: " + method.SourceFile.DisplayName + Environment.NewLine
+                                    + "DuplicateIdentifier: " + method.Identifier + Environment.NewLine;
+
+                    var duplicateFileFullPath = fileFullPath + "-duplicate" + count;
+                    FancyConsole.WriteLine(FancyConsole.ConsoleErrorColor, $"Writing {duplicateFileFullPath}");
+                    File.WriteAllText(duplicateFileFullPath, errorMessage);
+                }
+                else
+                {
+                    duplicates[fileName] = (method.SourceFile.DisplayName, method.Identifier, 1);
+                    FancyConsole.WriteLine(FancyConsole.ConsoleSuccessColor, $"Writing {fileFullPath}");
+                    File.WriteAllText(fileFullPath, ReplaceLFbyCRLF(request.FullHttpText(true)));
+                }
             }
         }
         private static string ReplaceLFbyCRLF(string original)


### PR DESCRIPTION
- fixes https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/1700
- partial https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/595
- adds temp-output-path as the temporary snippets output path
- removes the step that deletes the temp folder to allow further analysis of failures
- whenever there is a naming collision, it writes a duplicate file in the format:
  - `normalized-snippet-name-<version>-httpSnippet-duplicate<duplicateCount>`
  - in later pipelines, these outputs will be parsed for failure analysis.