### PR TITLE
Fixes snippet version parsing.

### DIFF
--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2265,7 +2265,18 @@ namespace ApiDoctor.ConsoleApp
         /// <returns>prefix representing method name and version</returns>
         private static string GetSnippetPrefix(MethodDefinition method)
         {
-            var version = GetSnippetVersion(method.Request);
+            string version;
+            try
+            {
+                // try to get the version from the url
+                version = GetSnippetVersion(method.Request);
+            }
+            catch (ArgumentException)
+            {
+                // default to using the file location. Error/Warning will be logged
+                version = GetSnippetVersion(method.SourceFile.DisplayName);
+            }
+            
             return GetSnippetPrefix(method.Identifier, version);
         }
 


### PR DESCRIPTION
This PR fixes a regression that would prevent snippet block parsing due to failed version lookup as previous versions of APIDoctor would do a best-effort attempt to obtain version for the snippets during generation.

If the version cannot be obtained from the URL, the version is inferred from the file location and a warning will continue to be logged as before for action from the documentation to fixed.

Sample generation at https://dev.azure.com/microsoftgraph/Graph%20Developer%20Experiences/_build/results?buildId=112494&view=results

Related to https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1477 

