### PR TITLE
Update permissions table generation

### DIFF
--- a/ApiDoctor.Console/Constants.cs
+++ b/ApiDoctor.Console/Constants.cs
@@ -10,19 +10,8 @@ namespace ApiDoctor.ConsoleApp
                     " Use a higher privileged permission or permissions [only if your app requires it](/graph/permissions-overview#best-practices-for-using-microsoft-graph-permissions)." +
                     " For details about delegated and application permissions, see [Permission types](/graph/permissions-overview#permission-types). To learn more about these permissions, see the [permissions reference](/graph/permissions-reference).";
             public const string MultipleTableBoilerPlateText = "The following tables show the least privileged permission or permissions required to call this API on each supported resource type." +
-                    " Follow [best practices](/graph/permissions-overview#best-practices-for-using-microsoft-graph-permissions) to request least privileged permissions." +
+                    " Follow [best practices](/graph/permissions-overview#best-practices-for-using-microsoft-graph-permissions) to request least privileged permissions." +
                     " For details about delegated and application permissions, see [Permission types](/graph/permissions-overview#permission-types). To learn more about these permissions, see the [permissions reference](/graph/permissions-reference).";
-            public static readonly List<string> BoilerplateTextsToReplace = new()
-            {
-                "One of the following permissions is required to call this API.",
-                "One of the following permissions are required to call this API.",
-                "One of the following permissions may be required to call this API.",
-                "One of the following sets of permissions is required to call this API.",
-                "One of the following permissions is required to call these APIs.",
-                "The following permission is required to call the API.",
-                "The following permission is required to call this API.",
-                "The following permissions are required to call this API."
-            };
         }
 
     }

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -28,6 +28,7 @@ namespace ApiDoctor.ConsoleApp
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -2621,7 +2622,8 @@ namespace ApiDoctor.ConsoleApp
                 var parseStatus = PermissionsInsertionState.FindPermissionsHeader;
                 int foundPermissionTablesOrBlocks = 0, foundHttpRequestBlocks = 0;
                 bool finishedParsing = false, isBootstrapped = false, ignorePermissionTableUpdate = false;
-                int insertionStartLine = -1, insertionEndLine = -1, httpRequestStartLine = -1, httpRequestEndLine = -1, boilerplateStartLine = -1, permissionsHeaderIndex = -1;
+                int insertionStartLine = -1, insertionEndLine = -1, httpRequestStartLine = -1, httpRequestEndLine = -1, 
+                    boilerplateStartLine = -1, boilerplateEndLine = -1, permissionsHeaderIndex = -1;
                 for (var currentIndex = 0; currentIndex < originalFileContents.Length && !finishedParsing; currentIndex++)
                 {
                     var currentLine = originalFileContents[currentIndex].Trim();
@@ -2635,14 +2637,9 @@ namespace ApiDoctor.ConsoleApp
                             }
                             break;
                         case PermissionsInsertionState.FindInsertionStartLine:
-                            if (Constants.PermissionConstants.BoilerplateTextsToReplace.Any(x => currentLine.StartsWith(x)))
-                            {
-                                boilerplateStartLine = currentIndex;
-                            }
-
                             if (currentLine.Contains("blockType", StringComparison.OrdinalIgnoreCase) && currentLine.Contains("\"ignored\""))
                                 ignorePermissionTableUpdate = true;
-
+                            
                             if (currentLine.Contains("[!INCLUDE [permissions-table](")) // bootstrapping already took place
                             {
                                 if (ignorePermissionTableUpdate)
@@ -2682,16 +2679,19 @@ namespace ApiDoctor.ConsoleApp
                                 insertionStartLine = currentIndex;
                                 parseStatus = PermissionsInsertionState.FindInsertionEndLine;
 
-                                // Find position to add boileplate text if missing
-                                if (foundPermissionTablesOrBlocks == 1 && boilerplateStartLine == -1)
+                                // Find position to add boileplate text
+                                if (foundPermissionTablesOrBlocks == 1)
                                 {
-                                    for (int index = currentIndex - 1; index >= permissionsHeaderIndex; index--)
+                                    boilerplateStartLine = permissionsHeaderIndex;
+                                    for (int index = permissionsHeaderIndex + 1; index < currentIndex; index++)
                                     {
-                                        // Break, if we encounter a non-standard boilerplate text
-                                        if (!string.IsNullOrWhiteSpace(originalFileContents[index]) && !originalFileContents[index].StartsWith('#'))
-                                            break;
-                                        if (index == permissionsHeaderIndex)
-                                            boilerplateStartLine = permissionsHeaderIndex;
+                                        // if the line is not empty and is not a sub header, this is the boilerplate start line
+                                       if (!string.IsNullOrWhiteSpace(originalFileContents[index]) && !originalFileContents[index].StartsWith('#'))  
+                                       {
+                                            if (boilerplateStartLine == permissionsHeaderIndex)
+                                                boilerplateStartLine = index;
+                                            boilerplateEndLine = index;
+                                       }
                                     }
                                 }
                             }
@@ -2706,6 +2706,13 @@ namespace ApiDoctor.ConsoleApp
                                     if (numberOfRows > 5)
                                     {
                                         FancyConsole.WriteLine(ConsoleColor.Yellow, $"Permissions table ({foundPermissionTablesOrBlocks}) in {docFile.DisplayName} was not updated because extra rows were found");
+                                        parseStatus = PermissionsInsertionState.FindNextPermissionBlock;
+                                        break;
+                                    }
+
+                                    if (originalFileContents[index].Contains("<sup>") || originalFileContents[index].Contains("*"))
+                                    {
+                                        FancyConsole.WriteLine(ConsoleColor.Yellow, $"Permissions table ({foundPermissionTablesOrBlocks}) in {docFile.DisplayName} was not updated because an astrerisk or superscript was found");
                                         parseStatus = PermissionsInsertionState.FindNextPermissionBlock;
                                         break;
                                     }
@@ -2802,6 +2809,13 @@ namespace ApiDoctor.ConsoleApp
                                             insertionEndLine++;
                                         }
                                         else {
+                                            if (boilerplateEndLine > boilerplateStartLine)
+                                            {
+                                                int extraLinesToRemove = boilerplateEndLine - boilerplateStartLine;
+                                                originalFileContents = originalFileContents.Splice(boilerplateStartLine + 1, extraLinesToRemove).ToArray();
+                                                insertionStartLine -= extraLinesToRemove;
+                                                insertionEndLine -= extraLinesToRemove;
+                                            }
                                             originalFileContents[boilerplateStartLine] = Constants.PermissionConstants.DefaultBoilerPlateText;
                                         }
                                     }

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2642,14 +2642,14 @@ namespace ApiDoctor.ConsoleApp
                             
                             if (currentLine.Contains("[!INCLUDE [permissions-table](")) // bootstrapping already took place
                             {
+                                foundPermissionTablesOrBlocks++;
                                 if (ignorePermissionTableUpdate)
                                 {
-                                    FancyConsole.WriteLine(ConsoleColor.Yellow, $"Skipping update of permissions table ({foundPermissionTablesOrBlocks + 1}) in {docFile.DisplayName}");
+                                    FancyConsole.WriteLine(ConsoleColor.Yellow, $"Skipping update of permissions table ({foundPermissionTablesOrBlocks}) in {docFile.DisplayName}");
                                     parseStatus = PermissionsInsertionState.FindNextPermissionBlock;
                                     break;
                                 }
 
-                                foundPermissionTablesOrBlocks++;
                                 isBootstrapped = true;
                                 if (!options.BootstrappingOnly)
                                 {
@@ -2668,14 +2668,14 @@ namespace ApiDoctor.ConsoleApp
                             }
                             else if (currentLine.Contains('|') && currentLine.Trim().Contains("Permission type", StringComparison.OrdinalIgnoreCase)) // found the permissions table
                             {
+                                foundPermissionTablesOrBlocks++;
                                 if (ignorePermissionTableUpdate)
                                 {
-                                    FancyConsole.WriteLine(ConsoleColor.Yellow, $"Skipping update of permissions table ({foundPermissionTablesOrBlocks + 1}) in {docFile.DisplayName}");
+                                    FancyConsole.WriteLine(ConsoleColor.Yellow, $"Skipping update of permissions table ({foundPermissionTablesOrBlocks}) in {docFile.DisplayName}");
                                     parseStatus = PermissionsInsertionState.FindNextPermissionBlock;
                                     break;
                                 }
 
-                                foundPermissionTablesOrBlocks++;
                                 insertionStartLine = currentIndex;
                                 parseStatus = PermissionsInsertionState.FindInsertionEndLine;
 

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2603,9 +2603,13 @@ namespace ApiDoctor.ConsoleApp
             var docSet = docs ?? await GetDocSetAsync(options, issues);
             if (null == docSet)
                 return false;
-
+         
             // we only expect to have permission definitions in documents of ApiPageType
             var docFiles = docSet.Files.Where(x => x.DocumentPageType == DocFile.PageType.ApiPageType);
+
+            // skip generation for workloads specified in config
+            var workloadsToSkip = DocSet.SchemaConfig?.SkipPermissionTableUpdateForWorkloads ?? new List<string>();
+            docFiles = docFiles.Where(f => !workloadsToSkip.Any(w => !string.IsNullOrWhiteSpace(f.DisplayName) && f.DisplayName.IContains(w)));
 
             // generate permissions document
             var permissionsDocument = new PermissionsDocument();
@@ -2615,7 +2619,7 @@ namespace ApiDoctor.ConsoleApp
                 if (permissionsDocument == null)
                     return false;
             }
-             
+
             foreach (var docFile in docFiles)
             {
                 var originalFileContents = await File.ReadAllLinesAsync(docFile.FullPath);

--- a/ApiDoctor.Validation/OData/Transformation/SchemaConfigFile.cs
+++ b/ApiDoctor.Validation/OData/Transformation/SchemaConfigFile.cs
@@ -47,6 +47,7 @@ namespace ApiDoctor.Validation.OData.Transformation
             FoldersToSkip = new List<string>();
             FilesToSkip = new List<string>();
             TreatErrorsAsWarningsWorkloads = new List<string>();
+            SkipPermissionTableUpdateForWorkloads = new List<string>();
         }
 
         /// <summary>
@@ -92,10 +93,16 @@ namespace ApiDoctor.Validation.OData.Transformation
         public List<string> FilesToSkip { get; set; }
 
         /// <summary>
-        /// optionally specify workloads whose errors should be treated as warnings
+        /// Optionally specify workloads whose errors should be treated as warnings
         /// </summary>
         [JsonProperty("treatErrorsAsWarningsWorkloads")]
         public List<string> TreatErrorsAsWarningsWorkloads { get; set; }
+
+        /// <summary>
+        /// Optionally exclude workloads from automatic update of permissions table
+        /// </summary>
+        [JsonProperty("skipPermissionTableUpdateForWorkloads")]
+        public List<string> SkipPermissionTableUpdateForWorkloads { get; set; }
     }
 
     public class SchemaDiffConfig


### PR DESCRIPTION
This PR
- Removes the need to replace only specific permissions table boilerplate text but replaces all. We're doing this because we've already established that all current texts should be replaced.
- Add ignored permissions tables to tally of found tables so that we can correctly map requests to tables
- Automatically skips update of permission files with asterisks and superscript because otherwise, important information would be overwritten.
- Automatically skips update of permissions files with keyword specified in config file of docs