### PR TITLE
Elevate API Doctor warnings to blocking errors if properties table + JSON representation don't match

### DIFF
--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -1154,11 +1154,6 @@ namespace ApiDoctor.Validation
                         {
                             paramsToRemove.Add(param);
                         }
-                        else
-                        {
-                            issues.Warning(ValidationErrorCode.AdditionalPropertyDetected,
-                                $"Property '{param.Name}' found in resource definition for '{onlyResource.Name}', but not described in markdown table.");
-                        }
                     }
                 }
 

--- a/ApiDoctor.Validation/DocSet.cs
+++ b/ApiDoctor.Validation/DocSet.cs
@@ -417,6 +417,16 @@ namespace ApiDoctor.Validation
                     {
                         EnsureDefinedInDocs(param.Type.CustomTypeName, definedTypes, resource.SourceFile, resourceIssues.For(param.Name));
                     }
+
+                    // if parameter does not have a description, then it's from the resource JSON definition
+                    if (string.IsNullOrEmpty(param.Description) && !param.Name.Contains('@'))
+                    {
+                        if (string.IsNullOrWhiteSpace(resource.BaseType) || !resource.ResolvedBaseTypeReference.HasOrInheritsProperty(param.Name))
+                        {
+                            issues.Error(ValidationErrorCode.AdditionalPropertyDetected,
+                                $"Property '{param.Name}' found in resource definition for '{resource.Name}', but not described in markdown table.");
+                        }
+                    }
                 }
 
                 if (!string.IsNullOrEmpty(resource.KeyPropertyName) &&


### PR DESCRIPTION
In this PR:
- Change warnings to errors if properties table + JSON representation don't match
- No error if property is defined in baseType