### PR TITLE
Skip validation of JSON properties against markdown table if resource is open type

### DIFF
--- a/ApiDoctor.Validation/CodeBlockAnnotation.cs
+++ b/ApiDoctor.Validation/CodeBlockAnnotation.cs
@@ -201,7 +201,7 @@ namespace ApiDoctor.Validation
 
         /// <summary>
         /// Indicates that a resource is extensible with additional properties that 
-        /// may not be defined in the documtnation.
+        /// may not be defined in the documentation.
         /// </summary>
         [JsonProperty("openType")]
         public bool IsOpenType { get; set; }

--- a/ApiDoctor.Validation/DocSet.cs
+++ b/ApiDoctor.Validation/DocSet.cs
@@ -419,7 +419,7 @@ namespace ApiDoctor.Validation
                     }
 
                     // if parameter does not have a description, then it's from the resource JSON definition
-                    if (string.IsNullOrEmpty(param.Description) && !param.Name.Contains('@'))
+                    if (string.IsNullOrEmpty(param.Description) && !param.Name.Contains('@') && !resource.OriginalMetadata.IsOpenType)
                     {
                         if (string.IsNullOrWhiteSpace(resource.BaseType) || !resource.ResolvedBaseTypeReference.HasOrInheritsProperty(param.Name))
                         {


### PR DESCRIPTION
Properties for open types are dynamic