### PR TITLE
Remove additional text from property names before validation

### DIFF
--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -36,7 +36,6 @@ namespace ApiDoctor.Validation
     using MarkdownDeep;
     using Newtonsoft.Json;
 
-
     /// <summary>
     /// A documentation file that may contain one more resources or API methods
     /// </summary>
@@ -503,7 +502,7 @@ namespace ApiDoctor.Validation
             return contentPreview;
         }
 
-        protected Config.DocumentHeader CreateHeaderFromBlock(Block block)
+        protected static Config.DocumentHeader CreateHeaderFromBlock(Block block)
         {
             var header = new Config.DocumentHeader();
             switch (block.BlockType)
@@ -1131,10 +1130,22 @@ namespace ApiDoctor.Validation
                                 return;
                             }
 
+                            var listOfTextToRemoveFromPropertyNames = DocSet.SchemaConfig?.TextToRemoveFromPropertyNames ?? [];
+                            var parametersFromTableDefinition = table.Rows.Cast<ParameterDefinition>()
+                            .Select(param =>
+                            {
+                                foreach (string text in listOfTextToRemoveFromPropertyNames)
+                                {
+                                    param.Name = param.Name.Replace(text, "").Trim();
+                                }
+                                return param;
+                            });
+
+
                             table.UsedIn.Add(onlyResource);
                             MergeParametersIntoCollection(
                                 onlyResource.Parameters,
-                                table.Rows.Cast<ParameterDefinition>(),
+                                parametersFromTableDefinition,
                                 issues.For(onlyResource.Name),
                                 addMissingParameters: true,
                                 expectedInResource: true,

--- a/ApiDoctor.Validation/DocSet.cs
+++ b/ApiDoctor.Validation/DocSet.cs
@@ -411,6 +411,7 @@ namespace ApiDoctor.Validation
                         $"Missing value for referenced base type in resource {resource.Name}");
                 }
 
+                var docIssues = issues.For(resource.SourceFile.DisplayName);
                 foreach (var param in resource.Parameters)
                 {
                     if (param.Type?.CustomTypeName != null)
@@ -423,7 +424,7 @@ namespace ApiDoctor.Validation
                     {
                         if (string.IsNullOrWhiteSpace(resource.BaseType) || !resource.ResolvedBaseTypeReference.HasOrInheritsProperty(param.Name))
                         {
-                            issues.Error(ValidationErrorCode.AdditionalPropertyDetected,
+                            docIssues.Error(ValidationErrorCode.AdditionalPropertyDetected,
                                 $"Property '{param.Name}' found in resource definition for '{resource.Name}', but not described in markdown table.");
                         }
                     }

--- a/ApiDoctor.Validation/OData/Transformation/SchemaConfigFile.cs
+++ b/ApiDoctor.Validation/OData/Transformation/SchemaConfigFile.cs
@@ -43,11 +43,12 @@ namespace ApiDoctor.Validation.OData.Transformation
     {
         public SchemaConfig()
         {
-            RequiredYamlHeaders = new string[] {};
-            FoldersToSkip = new List<string>();
-            FilesToSkip = new List<string>();
-            TreatErrorsAsWarningsWorkloads = new List<string>();
-            SkipPermissionTableUpdateForWorkloads = new List<string>();
+            RequiredYamlHeaders = [];
+            FoldersToSkip = [];
+            FilesToSkip = [];
+            TreatErrorsAsWarningsWorkloads = [];
+            SkipPermissionTableUpdateForWorkloads = [];
+
         }
 
         /// <summary>
@@ -103,6 +104,12 @@ namespace ApiDoctor.Validation.OData.Transformation
         /// </summary>
         [JsonProperty("skipPermissionTableUpdateForWorkloads")]
         public List<string> SkipPermissionTableUpdateForWorkloads { get; set; }
+
+        /// <summary>
+        /// Text to remove from property names
+        /// </summary>
+        [JsonProperty("textToRemoveFromPropertyNames")]
+        public List<string> TextToRemoveFromPropertyNames { get; set; }
     }
 
     public class SchemaDiffConfig


### PR DESCRIPTION
Some property names have text such as `(deprecated)` appended to them. The change in this PR will strip the additional text before validation.