### PR TITLE
Improve YAML validation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "dotnet.defaultSolution": "ApiDoctor.sln"
+}

--- a/ApiDoctor.Validation.UnitTests/YamlParserTests.cs
+++ b/ApiDoctor.Validation.UnitTests/YamlParserTests.cs
@@ -1,0 +1,60 @@
+/*
+ * API Doctor
+ * Copyright (c) Microsoft Corporation
+ * All rights reserved.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the ""Software""), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace ApiDoctor.Validation.UnitTests
+{
+    using ApiDoctor.Validation;
+    using ApiDoctor.Validation.Error;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class YamlParserTests
+    {
+        private static readonly string yamlWithMultiLineArray = @"title: ""Define the /me as singleton""
+description: ""These are things I had to add in the docs to make sure the Markdown-Scanner""
+ms.localizationpriority: medium
+author: """"
+ms.prod: """"
+doc_type: conceptualPageType
+toc.keywords:
+- foo
+- bar
+";
+
+        [Test]
+        public void YamlWithMultiLineArrayParses()
+        {
+            // Arrange
+            _ = new DocSet();
+            var issues = new IssueLogger();
+
+            // Act
+            DocFile.ParseYamlMetadata(yamlWithMultiLineArray, issues);
+
+            // Assert
+            Assert.That(!issues.Issues.WereErrors());
+        }
+    }
+}

--- a/ApiDoctor.Validation/ApiDoctor.Validation.csproj
+++ b/ApiDoctor.Validation/ApiDoctor.Validation.csproj
@@ -29,5 +29,10 @@
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IO.Packaging" Version="8.0.0" />
+    <PackageReference Include="YamlDotNet" Version="15.1.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ApiDoctor.Validation.UnitTests" />
   </ItemGroup>
 </Project>

--- a/ApiDoctor.Validation/Properties/AssemblyInfo.cs
+++ b/ApiDoctor.Validation/Properties/AssemblyInfo.cs
@@ -1,7 +1,8 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("ApiDoctor.Validation")]
@@ -13,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,12 +25,14 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: InternalsVisibleTo("ApiDoctor.Validation.UnitTests")]


### PR DESCRIPTION
Replaced custom string parsing with YamlDotNet deserializer, which handles more YAML formats.

Fixes #274 