### PR TITLE
Implement conditional update of permissions tables based on HTML comment command

### DIFF
--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -3051,7 +3051,7 @@ namespace ApiDoctor.ConsoleApp
                     var requestPermissions = generator.GenerateTable();
                     newPermissionFileContents ??= requestPermissions;
 
-                    if (newPermissionFileContents != requestPermissions)
+                   if (!newPermissionFileContents.Equals(requestPermissions, StringComparison.OrdinalIgnoreCase))
                     {
                         FancyConsole.WriteLine(ConsoleColor.Yellow, $"Encountered request URL(s) for permissions table ({permissionsTablePosition}) in {docFileName} with a different set of permissions");
                     }

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2690,7 +2690,7 @@ namespace ApiDoctor.ConsoleApp
                             {
                                 codeBlockAnnotationEndLine = currentIndex;
                             }
-                            else if (currentLine.Contains("[!INCLUDE [permissions-table](")) // bootstrapping already took place
+                            else if (currentLine.Contains("[!INCLUDE [permissions-table](", StringComparison.OrdinalIgnoreCase)) // bootstrapping already took place
                             {
                                 foundPermissionTablesOrBlocks++;
                                 if (ignorePermissionTableUpdate)
@@ -2986,7 +2986,7 @@ namespace ApiDoctor.ConsoleApp
                 : string.Empty;
 
             string mergePermissionsJson = mergePermissions
-                ? $",{newLineSpaces}\"mergePermissions\": {mergePermissions.ToString().ToLower()}"
+                ? $",{newLineSpaces}\"mergePermissions\": true"
                 : string.Empty;
 
 
@@ -3028,7 +3028,7 @@ namespace ApiDoctor.ConsoleApp
             {
                 try
                 {
-                    var generator = new PermissionsStubGenerator(permissionsDocument, concatenatedRequests, requestPaths.First().Method, false, true)
+                    var generator = new PermissionsStubGenerator(permissionsDocument, concatenatedRequests, requestPaths[0].Method, false, true)
                     {
                         MergeMultiplePaths = true
                     };
@@ -3036,7 +3036,7 @@ namespace ApiDoctor.ConsoleApp
                 }
                 catch (Exception ex)
                 {
-                    FancyConsole.WriteLine($"Could not fetch permissions for '{requestPaths.First().Method} {concatenatedRequests}': {ex.Message}");
+                    FancyConsole.WriteLine($"Could not fetch permissions for '{requestPaths[0].Method} {concatenatedRequests}': {ex.Message}");
                     return null;
                 }
             }

--- a/ApiDoctor.Validation.UnitTests/YamlParserTests.cs
+++ b/ApiDoctor.Validation.UnitTests/YamlParserTests.cs
@@ -85,7 +85,7 @@ toc.keywords:
             var error = issues.Issues.FirstOrDefault();
             Assert.That(error != null);
             Assert.That(error.IsError);
-            Assert.That(error.Message == "Incorrect YAML header format");
+            Assert.That(error.Message.FirstLineOnly() == "Incorrect YAML header format");
         }
     }
 }

--- a/ApiDoctor.Validation/CodeBlockAnnotation.cs
+++ b/ApiDoctor.Validation/CodeBlockAnnotation.cs
@@ -303,6 +303,19 @@ namespace ApiDoctor.Validation
         public string KeyPropertyName { get; set; }
 
         /// <summary>
+        /// Request URLs to use to populate permissions table.
+        /// </summary>
+        [JsonProperty("requestUrls", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] RequestUrls { get; set; }
+
+        /// <summary>
+        /// Instruction to merge permissions of requestUrls into one table. 
+        /// If false, there'll be an error if requestUrls do not share the same set of permissions.
+        /// </summary>
+        [JsonProperty("mergePermissions", DefaultValueHandling=DefaultValueHandling.Ignore)]
+        public bool MergePermissions { get; set; }
+
+        /// <summary>
         /// Use this property to declare that a custom function request is idempotent (has no side-effects).
         /// </summary>
         [JsonProperty("idempotent", DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -571,5 +584,10 @@ namespace ApiDoctor.Validation
         /// A block representing a test parameter definition for the preceding example
         /// </summary>
         TestParams,
+
+        /// <summary>
+        /// Permissions code block. A block representing parameters to use to populate permissions table
+        /// </summary>
+        Permissions
     }
 }

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -1111,7 +1111,7 @@ namespace ApiDoctor.Validation
         /// </summary>
         /// <param name="content"></param>
         /// <returns></returns>
-        private static string StripHtmlCommentTags(string content)
+        public static string StripHtmlCommentTags(string content)
         {
             const string startComment = "<!--";
             const string endComment = "-->";

--- a/ApiDoctor.Validation/DocFile.cs
+++ b/ApiDoctor.Validation/DocFile.cs
@@ -397,9 +397,10 @@ namespace ApiDoctor.Validation
             {
                 dictionary = yamlDeserializer.Deserialize<Dictionary<string, object>>(yamlMetadata);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                issues.Error(ValidationErrorCode.IncorrectYamlHeaderFormat, "Incorrect YAML header format");
+                issues.Error(ValidationErrorCode.IncorrectYamlHeaderFormat, "Incorrect YAML header format", ex);
+                return;
             }
 
             List<string> missingHeaders = new List<string>();


### PR DESCRIPTION
Closes #280

This PR:
- Logs when a set of URLs do not have the same set of permissions
- Logs when the number of HTTP request blocks are more than the number of permissions tables
- Processes new properties in the permissions HTML comment metadata, namely: `requestUrls` and `mergePermissions`