### PR TITLE
Updates to permissions tables generation

### DIFF
--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2678,15 +2678,18 @@ namespace ApiDoctor.ConsoleApp
                                 mergePermissions = annotation?.MergePermissions ?? false;
                             }
 
-                            if (currentLine.StartsWith("<!-- {") || currentLine.Contains("<!--{"))
+                            var nextLine = currentIndex + 1 < originalFileContents.Length ? originalFileContents[currentIndex + 1].Trim() : "";
+                            if (currentLine.StartsWith("<!-- {")
+                                || currentLine.StartsWith("<!--{")
+                                || (currentLine.StartsWith("<!--") && nextLine.StartsWith('{')))
                             {
                                 insertionStartLine = currentIndex;
-                                if (currentLine.Contains("} -->") || currentLine.Contains("}-->"))
+                                if (currentLine.EndsWith("-->"))
                                 {
                                     codeBlockAnnotationEndLine = currentIndex;
                                 }
                             }
-                            else if (currentLine.Contains("} -->") || currentLine.Contains("}-->"))
+                            else if (insertionStartLine >= 0 && currentLine.EndsWith("-->"))
                             {
                                 codeBlockAnnotationEndLine = currentIndex;
                             }

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2674,8 +2674,16 @@ namespace ApiDoctor.ConsoleApp
                                     : string.Join(" ", originalFileContents.Skip(insertionStartLine).Take(codeBlockAnnotationEndLine + 1 - insertionStartLine));
                                 var metadataJsonString = DocFile.StripHtmlCommentTags(htmlComment);
                                 var annotation = CodeBlockAnnotation.ParseMetadata(metadataJsonString);
-                                requestUrlsForPermissions = annotation?.RequestUrls;
-                                mergePermissions = annotation?.MergePermissions ?? false;
+                                if (annotation.BlockType == CodeBlockType.Permissions)
+                                {
+                                    requestUrlsForPermissions = annotation?.RequestUrls;
+                                    mergePermissions = annotation?.MergePermissions ?? false;
+                                }
+                                else
+                                {
+                                    insertionStartLine = -1;
+                                    codeBlockAnnotationEndLine = -1;
+                                }
                             }
 
                             var nextLine = currentIndex + 1 < originalFileContents.Length ? originalFileContents[currentIndex + 1].Trim() : "";


### PR DESCRIPTION
This PR
- Makes sure that we capture different formatting of the HTML comment metadata preceding the permissions table
- Adds missing HTML comment metadata to 'included' permissions table
- Handles exceptions thrown when attempting to deserialize JSON data in the HTML comment metadata
- Simplifies how we compute where to start looking for the next permissions table after finding the first one