### PR TITLE
Account for 'non-bootstraped' permissions tables that have HTML comment metadata

### DIFF
--- a/ApiDoctor.Console/Constants.cs
+++ b/ApiDoctor.Console/Constants.cs
@@ -5,7 +5,7 @@ namespace ApiDoctor.ConsoleApp
 {
     public static class Constants
     {
-        public static class PermissionConstants
+        public static class PermissionsConstants
         {
             public const string DefaultBoilerPlateText = "Choose the permission or permissions marked as least privileged for this API." +
                     " Use a higher privileged permission or permissions [only if your app requires it](/graph/permissions-overview#best-practices-for-using-microsoft-graph-permissions)." +

--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -2989,7 +2989,7 @@ namespace ApiDoctor.ConsoleApp
             for (var i = currentIndex - 1; i > 0; i--)
             {
                 var lineContents = originalFileContents[i].Trim();
-                if (!string.IsNullOrWhiteSpace(lineContents) && !lineContents.Contains("-->") && codeBlockAnnotationEndLine == -1)
+                if (!string.IsNullOrWhiteSpace(lineContents) && !lineContents.Contains("-->") && !lineContents.Contains("<!--") && codeBlockAnnotationEndLine == -1)
                 {
                     break;
                 }


### PR DESCRIPTION
The documentation team has begun manually creating permissions tables and adding metadata to guide API Doctor in populating these tables through Kibali. Initially, we assumed that non-bootstrapped tables lacked the HTML comment metadata. This PR ensures that the metadata is processed correctly