### PR TITLE
Do not emit errors in the console when comparing null permissions tables for request URLs within the same HTTP request block

### DIFF
--- a/ApiDoctor.Console/Program.cs
+++ b/ApiDoctor.Console/Program.cs
@@ -3143,7 +3143,7 @@ namespace ApiDoctor.ConsoleApp
                     var requestPermissions = generator.GenerateTable();
                     newPermissionFileContents ??= requestPermissions;
 
-                    if (!newPermissionFileContents.Equals(requestPermissions, StringComparison.OrdinalIgnoreCase))
+                    if (!string.IsNullOrWhiteSpace(newPermissionFileContents) && !string.IsNullOrWhiteSpace(requestPermissions) && !newPermissionFileContents.Equals(requestPermissions, StringComparison.OrdinalIgnoreCase))
                     {
                         FancyConsole.WriteLine(ConsoleColor.Yellow, $"Encountered request URL(s) for permissions table ({permissionsTablePosition}) in {docFileName} with a different set of permissions");
                     }


### PR DESCRIPTION
This is to help in identifying request blocks that do not have the same set of permissions for action by the content team