### PR TITLE
Migrate GitHub Pages to modern Actions-based deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+apidoctor.md


### PR DESCRIPTION
## Summary

- Replaces the classic "Deploy from branch" Pages setup with a GitHub Actions workflow
- Uses the modern `configure-pages` → `jekyll-build-pages` → `upload-pages-artifact` → `deploy-pages` action stack
- Moves `CNAME` into the `docs/` source directory so the custom domain (`apidoctor.md`) is preserved in the built site

## Post-merge manual step

In the repo **Settings → Pages**, change the source from **"Deploy from a branch"** to **"GitHub Actions"** to complete the migration.

## Test plan

- [ ] PR workflow runs green
- [ ] After merge, confirm the `Deploy GitHub Pages` workflow triggers and completes successfully
- [ ] Verify the site is live at the custom domain after switching the Pages source setting to GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)